### PR TITLE
chore: add .gitattributes and .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Enforce LF line endings for all text files
+* text=auto eol=lf
+
+# Explicitly mark binary files
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary
+*.pdf binary


### PR DESCRIPTION
## Summary
- Adds `.gitattributes` to enforce LF line endings for all text files, preventing CRLF/LF mismatches across the team
- Adds `.editorconfig` for consistent editor settings (UTF-8, LF, spaces, trailing whitespace)

## Test plan
- [x] Verify `.gitattributes` and `.editorconfig` are present with correct content
- [ ] Confirm no unintended file changes from renormalization

🤖 Generated with [Claude Code](https://claude.com/claude-code)