### PR TITLE
adjusted code and readme

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,27 @@
 # This should be used for local development purposes only.
 #
 # Best practices: https://postmarkapp.com/blog/how-to-keep-your-postmark-account-secure-best-practices-guide
+
+# ── Required ──────────────────────────────────────────────────────────────────
 POSTMARK_SERVER_TOKEN=your-postmark-server-token
 DEFAULT_SENDER_EMAIL=info@example.com
 DEFAULT_MESSAGE_STREAM=outbound
+
+# ── Optional ──────────────────────────────────────────────────────────────────
+
+# Label for this instance — sent as X-Agent-Label on every Postmark API request.
+# Useful for identifying traffic sources in logs or support tickets.
+#AGENT_LABEL=
+
+# Comma-separated HTTPS URL prefixes that createWebhook will accept.
+# When set, any URL not matching a listed prefix is rejected.
+# Example: WEBHOOK_URL_ALLOWLIST=https://hooks.yourapp.com,https://inbound.corp.io
+#WEBHOOK_URL_ALLOWLIST=
+
+# Path to a file where structured JSON logs are appended (in addition to stderr).
+# The file is created if it does not exist.
+#LOG_FILE=
+
+# Set to true to log email addresses without masking.
+# By default the mailbox portion is partially masked (u**r@example.com).
+#LOG_EMAIL_FULL=false

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules/
-package-lock.json
 yarn.lock
 bun.lock
 .env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-06-17
+
+### Added
+
+- **Structured JSON logging to stderr.** Every tool invocation emits a log line with `{ timestamp, tool, clientName, clientVersion, sanitizedArgs, status, durationMs }`. Optional `LOG_FILE` env var additionally appends logs to a file for persistence and support escalation.
+- **Email address masking in logs.** PII-safe by default — the mailbox is partially masked (first and last character retained, middle replaced with `***`), domain logged in full. Set `LOG_EMAIL_FULL=true` to disable masking. Implemented in `lib/log.js`, which also sanitizes body content and API keys from logged arguments.
+- **MCP client identity capture.** The `initialize` handshake captures the connecting client's name and version from the MCP protocol and attaches them to every log entry and outbound request header (`X-Postmark-MCP-Client: <name>/<version>`).
+- **`AGENT_LABEL` env var and `X-Agent-Label` request header.** Allows operators to tag their MCP server instance with a label that is sent on every Postmark API request, enabling traffic attribution in server logs or API usage reports.
+- **MCP tool annotations.** All 24 tools are annotated with `readOnlyHint`, `destructiveHint`, and `idempotentHint` so MCP clients can display risk indicators and gate destructive actions appropriately.
+- **Tool descriptions.** All 24 `server.tool()` registrations now include a concise description string, improving tool discovery and LLM decision-making.
+- **`sendEmail` multi-recipient support.** The `to` field now accepts either a single address string or an array of up to 50 addresses. Added optional `cc`, `bcc`, and `replyTo` fields.
+- **`sendEmailWithTemplate` improvements.** Added `cc`, `bcc`, and `replyTo` fields. Added a mutual-exclusivity guard: supplying both `templateId` and `templateAlias` now fails fast with a descriptive error rather than sending an ambiguous request.
+- **Webhook URL allowlist (`WEBHOOK_URL_ALLOWLIST`).** Set this env var to a comma-separated list of HTTPS URL prefixes; `createWebhook` will reject any URL that does not match. When unset, any valid HTTPS URL is accepted.
+- **Actionable startup error messages.** Missing or invalid configuration now produces messages that name the env var, explain the consequence, and link to the relevant Postmark documentation page.
+- **`npx`-based client configuration snippet in README.** Covers Cursor, Claude Desktop, and Windsurf — no local clone required.
+- **Automated test suite (52 tests across 3 tiers).**
+  - *Tier 1 — Unit* (`npm test`): 34 tests for `maskEmail`, `sanitizeArgs`, and `writeLog` in `lib/log.js`.
+  - *Tier 2 — Offline MCP validation* (`npm run test:offline`): 11 tests covering webhook HTTPS enforcement, allowlist behavior, and tool annotation correctness — no Postmark account required.
+  - *Tier 3 — E2E env var wiring* (`npm run test:e2e`): 7 tests verifying `LOG_FILE`, `LOG_EMAIL_FULL`, and MCP client identity capture end-to-end.
+- **`POSTMARK_SKIP_VERIFY` env var.** Bypasses the startup `/server` connectivity check; intended for test environments and offline use.
+
+### Changed
+
+- **`createWebhook` now requires HTTPS.** The `url` input is validated to start with `https://`; HTTP webhook URLs are rejected at the Zod schema level before any API call is made.
+- **`listTemplates` response includes a truncation notice** when exactly 100 templates are returned, since the Postmark API caps this endpoint at 100 results with no pagination.
+- **`searchBounces` and `searchOutboundMessages` document the 10,000 pagination cap.** The `offset` field description now notes that `count + offset` cannot exceed 10,000, matching Postmark API behavior.
+- **`deleteTemplate` documentation notes Layout template constraints.** Layout templates that are referenced by other templates cannot be deleted until dependents are unbound or reassigned.
+- **Logging extracted to `lib/log.js`.** A `createLogger` factory is exported, making the logging utilities independently testable and reusable.
+- **Dependencies pinned to exact versions** (`@modelcontextprotocol/sdk@1.29.0`, `dotenv@16.6.1`, `zod@3.25.76`) to reduce supply chain risk.
+- **`package-lock.json` is now committed.** Removed from `.gitignore` so `npm ci` installs a reproducible, audited dependency tree.
+
 ## [2.0.0] - 2026-06-12
 
 This release expands the MCP tool surface from 4 tools to 24, organized into eight categories. It includes one breaking change for users on Node 16 or 18.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Structured JSON logging to stderr.** Every tool invocation emits a log line with `{ timestamp, tool, clientName, clientVersion, sanitizedArgs, status, durationMs }`. Optional `LOG_FILE` env var additionally appends logs to a file for persistence and support escalation.
-- **Email address masking in logs.** PII-safe by default — the mailbox is partially masked (first and last character retained, middle replaced with `***`), domain logged in full. Set `LOG_EMAIL_FULL=true` to disable masking. Implemented in `lib/log.js`, which also sanitizes body content and API keys from logged arguments.
+- **Email address masking in logs.** PII-safe by default — the mailbox is partially masked (first and last characters retained, middle replaced with length-proportional asterisks — e.g. `alice@example.com` → `a***e@example.com`), domain logged in full. Set `LOG_EMAIL_FULL=true` to disable masking. Implemented in `lib/log.js`, which also sanitizes body content and API keys from logged arguments.
 - **MCP client identity capture.** The `initialize` handshake captures the connecting client's name and version from the MCP protocol and attaches them to every log entry and outbound request header (`X-Postmark-MCP-Client: <name>/<version>`).
 - **`AGENT_LABEL` env var and `X-Agent-Label` request header.** Allows operators to tag their MCP server instance with a label that is sent on every Postmark API request, enabling traffic attribution in server logs or API usage reports.
 - **MCP tool annotations.** All 24 tools are annotated with `readOnlyHint`, `destructiveHint`, and `idempotentHint` so MCP clients can display risk indicators and gate destructive actions appropriately.
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`X-Postmark-Client` correlation-id header replaced.** The `v2.0.0` request header `X-Postmark-Client: <version> / <uuid>` (per-request correlation UUID) has been replaced by two purpose-specific headers: `X-Postmark-MCP-Client: <name>/<version>` (MCP client identity from the `initialize` handshake) and `X-Agent-Label: <value>` (operator-supplied instance tag via `AGENT_LABEL`). If you built tooling to parse the old `X-Postmark-Client` header format, update accordingly.
 - **`createWebhook` now requires HTTPS.** The `url` input is validated to start with `https://`; HTTP webhook URLs are rejected at the Zod schema level before any API call is made.
 - **`listTemplates` response includes a truncation notice** when exactly 100 templates are returned, since the Postmark API caps this endpoint at 100 results with no pagination.
 - **`searchBounces` and `searchOutboundMessages` document the 10,000 pagination cap.** The `offset` field description now notes that `count + offset` cannot exceed 10,000, matching Postmark API behavior.
@@ -35,6 +36,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Logging extracted to `lib/log.js`.** A `createLogger` factory is exported, making the logging utilities independently testable and reusable.
 - **Dependencies pinned to exact versions** (`@modelcontextprotocol/sdk@1.29.0`, `dotenv@16.6.1`, `zod@3.25.76`) to reduce supply chain risk.
 - **`package-lock.json` is now committed.** Removed from `.gitignore` so `npm ci` installs a reproducible, audited dependency tree.
+- **`npm run smoke` and `npm run smoke:mutating` scripts.** `smoke:mutating` is a new script for the mutating harness. Both now include a `pre` hook that detects the missing local file and prints the exact `cp` command to run rather than letting Node throw a cryptic "module not found" error.
+
+### Fixed
+
+- **`sendEmail` leaked unmasked recipient address to stderr.** A stray `console.error(to, subject)` inside the handler fired before the structured logging wrapper ran, bypassing all sanitization and masking. Removed.
+- **`cc` and `bcc` comma-separated addresses were not masked.** When multiple addresses were supplied as a comma-separated string (e.g. `"alice@example.com, bob@example.com"`), the value did not match the single-address regex and was logged in full. The sanitizer now splits, masks each address individually, and rejoins.
 
 ## [2.0.0] - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,11 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`package-lock.json` is now committed.** Removed from `.gitignore` so `npm ci` installs a reproducible, audited dependency tree.
 - **`npm run smoke` and `npm run smoke:mutating` scripts.** `smoke:mutating` is a new script for the mutating harness. Both now include a `pre` hook that detects the missing local file and prints the exact `cp` command to run rather than letting Node throw a cryptic "module not found" error.
 
-### Fixed
-
-- **`sendEmail` leaked unmasked recipient address to stderr.** A stray `console.error(to, subject)` inside the handler fired before the structured logging wrapper ran, bypassing all sanitization and masking. Removed.
-- **`cc` and `bcc` comma-separated addresses were not masked.** When multiple addresses were supplied as a comma-separated string (e.g. `"alice@example.com, bob@example.com"`), the value did not match the single-address regex and was logged in full. The sanitizer now splits, masks each address individually, and rejoins.
-
 ## [2.0.0] - 2026-06-12
 
 This release expands the MCP tool surface from 4 tools to 24, organized into eight categories. It includes one breaking change for users on Node 16 or 18.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Planned (deferred from v2.1.0)
+
+- **`getWebhook` tool** — retrieve a single webhook's full configuration by ID (`GET /webhooks/{Id}`). Currently only `listWebhooks` is available; getting a single webhook requires filtering the list by ID.
+- **`editWebhook` tool** — update an existing webhook's URL, auth, headers, or trigger settings in place (`PUT /webhooks/{Id}`). Without this, changing any property requires deleting and recreating the webhook, creating a delivery gap.
+- **`createWebhook`: `postFirstOpenOnly` parameter** — when Open trigger is enabled, fire only on the first open per message rather than every open.
+- **`createWebhook`: `bounceIncludeContent` / `spamIncludeContent` parameters** — include the full email body in Bounce and SpamComplaint webhook payloads.
+- **CI** — add automated test gating on pull requests.
+- **Async log writes** — improve log write performance under burst load when `LOG_FILE` is configured.
+
+---
+
 ## [2.1.0] - 2026-06-17
 
 ### Added
 
 - **Structured JSON logging to stderr.** Every tool invocation emits a log line with `{ timestamp, tool, clientName, clientVersion, sanitizedArgs, status, durationMs }`. Optional `LOG_FILE` env var additionally appends logs to a file for persistence and support escalation.
-- **Email address masking in logs.** PII-safe by default — the mailbox is partially masked (first and last characters retained, middle replaced with length-proportional asterisks — e.g. `alice@example.com` → `a***e@example.com`), domain logged in full. Set `LOG_EMAIL_FULL=true` to disable masking. Implemented in `lib/log.js`, which also sanitizes body content and API keys from logged arguments.
+- **Email address masking in logs.** PII-reduced by default — the mailbox is partially masked (first and last characters retained, middle replaced with length-proportional asterisks — e.g. `alice@example.com` → `a***e@example.com`), domain logged in full. This is pseudonymization, not full anonymization: the domain and first/last initials are preserved. Set `LOG_EMAIL_FULL=true` to disable masking. Implemented in `lib/log.js`, which also sanitizes body content and API keys from logged arguments.
 - **MCP client identity capture.** The `initialize` handshake captures the connecting client's name and version from the MCP protocol and attaches them to every log entry and outbound request header (`X-Postmark-MCP-Client: <name>/<version>`).
 - **`AGENT_LABEL` env var and `X-Agent-Label` request header.** Allows operators to tag their MCP server instance with a label that is sent on every Postmark API request, enabling traffic attribution in server logs or API usage reports.
 - **MCP tool annotations.** All 24 tools are annotated with `readOnlyHint`, `destructiveHint`, and `idempotentHint` so MCP clients can display risk indicators and gate destructive actions appropriately.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Send emails with Postmark using Claude and other MCP-compatible AI assistants.
 ## Features
 - Exposes a Model Context Protocol (MCP) server backed by your [Postmark account](https://account.postmarkapp.com/sign_up)
 - 24 tools spanning email sending (single + batch), templates (CRUD + validation), message search, delivery diagnostics, bounces, suppressions, stats, server info, and webhooks
-- MCP tool annotations (`readOnlyHint`, `destructiveHint`) let supporting clients auto-approve safe reads and prompt before destructive or sending operations
+- MCP tool annotations (`readOnlyHint`, `destructiveHint`) let supporting clients auto-approve safe reads and require confirmation before mutating or destructive operations
 - Simple configuration via environment variables
 - Comprehensive error handling and graceful shutdown
 - Structured JSON logging to stderr with optional log-file persistence; email addresses are partially masked by default
@@ -73,7 +73,7 @@ Edit your `.env` to contain your Postmark credentials and settings.
 |---|---|---|
 | `AGENT_LABEL` | — | A label for this instance (e.g., `prod`, `staging`). Sent as `X-Agent-Label` on every Postmark API request, useful for identifying traffic sources in logs or support tickets. |
 | `WEBHOOK_URL_ALLOWLIST` | — | Comma-separated list of HTTPS URL prefixes that `createWebhook` will accept (e.g., `https://hooks.yourapp.com,https://inbound.corp.io`). When unset, any valid HTTPS URL is accepted. |
-| `LOG_FILE` | — | Path to a file where structured JSON logs are appended in addition to stderr. The file is created if it does not exist. |
+| `LOG_FILE` | — | Path to a file where structured JSON logs are appended in addition to stderr. The file is created if it does not exist. No rotation or size cap is applied — use an external tool such as `logrotate` to manage the file in long-running deployments. |
 | `LOG_EMAIL_FULL` | `false` | Set to `true` to log email addresses without masking. By default the mailbox portion is partially masked in logs (`u**r@example.com`). |
 
 **Run the server:**
@@ -731,10 +731,12 @@ The 24 tools include several high-impact operations. Below is the breakdown by r
 | **Additive** (account-state changes) | `createTemplate`, `createSuppressions`, `createWebhook`, `activateBounce` |
 | **Read-only** | All remaining 12 tools |
 
-All tools carry MCP annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`). MCP clients that respect annotations — including Cursor and Claude Desktop — will surface confirmation prompts for destructive and sending operations and can auto-approve safe read-only lookups.
+All tools carry MCP annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`). MCP clients that respect annotations — including Cursor and Claude Desktop — can auto-approve safe read-only lookups (`readOnlyHint: true`) and will surface confirmation prompts for anything that isn't a read: sends, template edits, suppression changes, and webhook management. Tools that permanently delete data additionally carry `destructiveHint: true` for clients that distinguish destructive from merely mutating actions.
 
 ### Webhook URL policy
 `createWebhook` enforces HTTPS on all URLs. Once a webhook is registered, Postmark will POST event data (opens, clicks, bounces, spam complaints) to that URL on an ongoing basis until the webhook is deleted. To prevent a compromised or misdirected tool call from registering a callback you don't control, set `WEBHOOK_URL_ALLOWLIST` to the HTTPS prefixes you own. Audit registered webhooks regularly with `listWebhooks` or via the [Postmark dashboard](https://account.postmarkapp.com).
+
+To secure your webhook receiver, whitelist [Postmark's published sending IPs](https://postmarkapp.com/support/article/800-what-are-the-postmark-ip-addresses) at the network or firewall level so only Postmark can POST to your endpoint.
 
 ### Prompt injection risk
 Because this MCP server can send email and register webhooks, it is a potential target for [prompt injection](https://owasp.org/www-project-top-10-for-large-language-model-applications/) — where malicious content in an email, template, or repository tricks the AI into invoking a tool with unintended arguments. The mitigations above (dedicated token, tool approval in your MCP client, `WEBHOOK_URL_ALLOWLIST`) reduce the blast radius if this occurs. Never configure auto-approval for sending or destructive tools in untrusted environments.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@ Send emails with Postmark using Claude and other MCP-compatible AI assistants.
 ## Features
 - Exposes a Model Context Protocol (MCP) server backed by your [Postmark account](https://account.postmarkapp.com/sign_up)
 - 24 tools spanning email sending (single + batch), templates (CRUD + validation), message search, delivery diagnostics, bounces, suppressions, stats, server info, and webhooks
+- MCP tool annotations (`readOnlyHint`, `destructiveHint`) let supporting clients auto-approve safe reads and prompt before destructive or sending operations
 - Simple configuration via environment variables
 - Comprehensive error handling and graceful shutdown
-- Secure logging practices (no sensitive data exposure)
+- Structured JSON logging to stderr with optional log-file persistence; email addresses are partially masked by default
+- HTTPS enforcement and optional domain allowlist for webhook registration
 - Automatic open/click tracking on every send
 
 ## Useful Docs
@@ -57,11 +59,22 @@ Edit your `.env` to contain your Postmark credentials and settings.
 
 **Important:** This is intended for local development purposes only. Secrets should never be stored in version control and `.env` type files should be added to `.gitignore`.
 
-| Variable                  | Description                                      | Required   |
-|---------------------------|--------------------------------------------------|------------|
-| POSTMARK_SERVER_TOKEN     | Your Postmark server API token                   | Yes        |
-| DEFAULT_SENDER_EMAIL      | Default sender email address                     | Yes        |
-| DEFAULT_MESSAGE_STREAM    | Postmark message stream (e.g., 'outbound')       | Yes        |
+### Required
+
+| Variable | Description |
+|---|---|
+| `POSTMARK_SERVER_TOKEN` | Your Postmark server API token |
+| `DEFAULT_SENDER_EMAIL` | Default sender email address (must be a verified sender in Postmark) |
+| `DEFAULT_MESSAGE_STREAM` | Postmark message stream (e.g., `outbound`) |
+
+### Optional
+
+| Variable | Default | Description |
+|---|---|---|
+| `AGENT_LABEL` | — | A label for this instance (e.g., `prod`, `staging`). Sent as `X-Agent-Label` on every Postmark API request, useful for identifying traffic sources in logs or support tickets. |
+| `WEBHOOK_URL_ALLOWLIST` | — | Comma-separated list of HTTPS URL prefixes that `createWebhook` will accept (e.g., `https://hooks.yourapp.com,https://inbound.corp.io`). When unset, any valid HTTPS URL is accepted. |
+| `LOG_FILE` | — | Path to a file where structured JSON logs are appended in addition to stderr. The file is created if it does not exist. |
+| `LOG_EMAIL_FULL` | `false` | Set to `true` to log email addresses without masking. By default the mailbox portion is partially masked in logs (`u**r@example.com`). |
 
 **Run the server:**
 
@@ -226,7 +239,9 @@ Template: welcome
 ```
 
 ### sendBatch
-Sends up to 500 emails in a single API call. Each message is fully independent (its own recipient, subject, body). This wraps Postmark's *synchronous* batch endpoint (`POST /email/batch`) — the call returns immediate per-message results — and synthesizes the success/failure summary. (Postmark also offers a separate *asynchronous* [bulk email API](https://postmarkapp.com/developer/api/bulk-email) at `/email/bulk` for large-volume jobs with submit-and-poll workflow, no message count cap, and a 50 MB payload limit. That's a parallel capability for different use cases — not currently wrapped by this MCP, tracked as a v2.1 follow-up.)
+Sends up to 500 emails in a single API call. Each message is fully independent — its own recipient, subject, and body. This wraps Postmark's *synchronous* batch endpoint (`POST /email/batch`), which returns immediate per-message results.
+
+> **Note:** Postmark also offers an asynchronous [bulk email API](https://postmarkapp.com/developer/api/bulk-email) (`POST /email/bulk`) for large-volume jobs with no message-count cap and a 50 MB payload limit. That endpoint uses a submit-and-poll workflow and is not currently wrapped by this MCP server.
 
 **Expected Payload:**
 ```json
@@ -580,10 +595,14 @@ Lists configured webhooks. Optional `messageStream` filter.
 ### createWebhook
 Creates a webhook subscription. Requires a `url` and **at least one** trigger.
 
+**Security note:** Webhooks are persistent — once registered, Postmark will POST event data (opens, clicks, bounces, spam complaints, etc.) to the target URL for all future matching events on that server, until the webhook is deleted. Only register webhooks pointing to URLs you control. Use `WEBHOOK_URL_ALLOWLIST` to restrict accepted URLs to known prefixes.
+
+The `url` must use **HTTPS**. HTTP URLs are rejected. If `WEBHOOK_URL_ALLOWLIST` is set, the URL must also match one of the configured prefixes.
+
 **Expected Payload:**
 ```json
 {
-  "url": "https://example.com/postmark-hook",
+  "url": "https://hooks.yourapp.com/postmark",
   "messageStream": "outbound",
   "openEnabled": true,
   "clickEnabled": true,
@@ -601,15 +620,16 @@ Deletes a webhook by ID.
 
 ## Implementation Details
 ### API Request Headers
-All requests to the Postmark API that are made directly by this server include the following headers for client identification and correlation:
+All requests to the Postmark API include the following headers for client identification:
 
 | Header | Description |
-|--------|-------------|
-| `X-Postmark-Client` | Client identifier: `postmark-mcp` |
-| `X-Postmark-Client-Version` | Version of this MCP server (matches package version) |
-| `X-Postmark-Correlation-Id` | A unique ID per request (UUID v4) for correlating requests with your logs or support. The API may use this in the future; it is safe to send now. |
+|---|---|
+| `X-Postmark-Client` | Always `postmark-mcp` — identifies this server as the request origin |
+| `X-Postmark-Client-Version` | Version of this MCP server, matching the package version |
+| `X-Postmark-MCP-Client` | Name and version of the MCP host application (e.g., `claude-desktop/1.0`), captured from the MCP `initialize` handshake. Omitted if the client does not provide this information. |
+| `X-Agent-Label` | Value of the `AGENT_LABEL` environment variable. Omitted when not set. |
 
-These headers are sent on **every** request to the Postmark API. This server uses its own HTTP client (no postmark npm package) so that MCP traffic is identified as `postmark-mcp` and not as the Node.js SDK.
+This server uses its own HTTP client (no postmark npm package) so that MCP traffic is identifiable as `postmark-mcp` in Postmark logs and support tickets.
 
 ### Automatic Configuration
 All emails are automatically configured with:
@@ -626,13 +646,74 @@ The server implements comprehensive error handling:
 - Consistent error message formatting
 
 ### Logging
-- Uses appropriate log levels (`info` for normal operations, `error` for errors)
-- Excludes sensitive information from logs
-- Provides clear operation status and results
+Every tool invocation emits a structured JSON line to **stderr**. If `LOG_FILE` is set, the same line is also appended to that file.
+
+**Log entry shape:**
+```json
+{
+  "timestamp": "2026-06-16T20:34:01.123Z",
+  "tool": "sendEmail",
+  "clientName": "claude-desktop",
+  "clientVersion": "1.0",
+  "args": {
+    "to": "u**r@example.com",
+    "subject": "Meeting Reminder",
+    "textBody": "[312ch]"
+  },
+  "status": "ok",
+  "durationMs": 243
+}
+```
+
+On error, `status` is `"error"` and an `error` field contains the message.
+
+**What is and isn't logged:**
+
+| Data | Logged as |
+|---|---|
+| Email addresses | Partially masked: `u**r@example.com` (set `LOG_EMAIL_FULL=true` to disable) |
+| `htmlBody` / `textBody` | Byte count only: `[312ch]` |
+| `templateModel` and other data objects | Key names only: `{ "_keys": ["name", "plan"] }` |
+| Batch `messages` / `recipients` arrays | Count + recipient list: `{ "_count": 2, "_recipients": ["u**r@…", "a*b@…"] }` |
+| Fields matching `password`, `secret`, `token`, `apikey` | `[redacted]` |
+| Tool name, duration, MCP client identity, status | Logged in full |
+
+> Unstructured operational messages (startup, shutdown, API connectivity) continue to write to stderr as plain text alongside the JSON tool logs.
 
 ---
 
-*For more information about the Postmark API, visit [Postmark's Developer Documentation](https://postmarkapp.com/developer).* 
+## Security Considerations
+
+### Access scope
+This MCP server acts with the full permissions of the configured `POSTMARK_SERVER_TOKEN`. It exposes 24 tools — including bulk email sends, template management, webhook registration, and suppression list edits — to any MCP client that connects.
+
+Postmark has [two token types](https://postmarkapp.com/developer/api/overview#authentication): a **Server Token** (used here) and an **Account Token**. Neither supports sub-scoped permissions — a Server Token grants full access to all operations on the server it belongs to. The practical way to limit exposure is structural:
+
+- Create a **dedicated Postmark server** used exclusively for MCP traffic. A compromise is then limited to that server's data and settings rather than your entire account.
+- Configure that server with only the message streams and verified sender signatures it actually needs.
+- Rotate the token if it is ever exposed.
+
+### Tool blast radius
+The 24 tools include several high-impact operations. Below is the breakdown by risk level:
+
+| Category | Tools |
+|---|---|
+| **Destructive** (irreversible) | `editTemplate`, `deleteTemplate`, `deleteWebhook`, `deleteSuppressions` |
+| **Sending** (outbound email) | `sendEmail`, `sendEmailWithTemplate`, `sendBatch`, `sendBatchWithTemplate` |
+| **Additive** (account-state changes) | `createTemplate`, `createSuppressions`, `createWebhook`, `activateBounce` |
+| **Read-only** | All remaining 12 tools |
+
+All tools carry MCP annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`). MCP clients that respect annotations — including Cursor and Claude Desktop — will surface confirmation prompts for destructive and sending operations and can auto-approve safe read-only lookups.
+
+### Webhook URL policy
+`createWebhook` enforces HTTPS on all URLs. Once a webhook is registered, Postmark will POST event data (opens, clicks, bounces, spam complaints) to that URL on an ongoing basis until the webhook is deleted. To prevent a compromised or misdirected tool call from registering a callback you don't control, set `WEBHOOK_URL_ALLOWLIST` to the HTTPS prefixes you own. Audit registered webhooks regularly with `listWebhooks` or via the [Postmark dashboard](https://account.postmarkapp.com).
+
+### Prompt injection risk
+Because this MCP server can send email and register webhooks, it is a potential target for [prompt injection](https://owasp.org/www-project-top-10-for-large-language-model-applications/) — where malicious content in an email, template, or repository tricks the AI into invoking a tool with unintended arguments. The mitigations above (dedicated token, tool approval in your MCP client, `WEBHOOK_URL_ALLOWLIST`) reduce the blast radius if this occurs. Never configure auto-approval for sending or destructive tools in untrusted environments.
+
+---
+
+*For more information about the Postmark API, visit [Postmark's Developer Documentation](https://postmarkapp.com/developer).*
 
 ## License
 [MIT](LICENSE) © ActiveCampaign

--- a/README.md
+++ b/README.md
@@ -118,22 +118,47 @@ After installing the MCP, update your configuration to set:
 - `DEFAULT_SENDER_EMAIL`
 - `DEFAULT_MESSAGE_STREAM` (default: `outbound`)
 
-## Claude and Cursor MCP Configuration Example
+## MCP Client Configuration
+
+### Using npx (recommended — no clone required)
+
+Install directly from npm without managing a local copy:
+
 ```json
 {
   "mcpServers": {
     "postmark": {
-      "command": "node",
-      "args": ["path/to/postmark-mcp/index.js"],
+      "command": "npx",
+      "args": ["-y", "@activecampaign/postmark-mcp"],
       "env": {
         "POSTMARK_SERVER_TOKEN": "your-postmark-server-token",
         "DEFAULT_SENDER_EMAIL": "your-sender-email@example.com",
-        "DEFAULT_MESSAGE_STREAM": "your-message-stream"
+        "DEFAULT_MESSAGE_STREAM": "outbound"
       }
     }
   }
 }
 ```
+
+### Using a local clone
+
+```json
+{
+  "mcpServers": {
+    "postmark": {
+      "command": "node",
+      "args": ["/absolute/path/to/postmark-mcp/index.js"],
+      "env": {
+        "POSTMARK_SERVER_TOKEN": "your-postmark-server-token",
+        "DEFAULT_SENDER_EMAIL": "your-sender-email@example.com",
+        "DEFAULT_MESSAGE_STREAM": "outbound"
+      }
+    }
+  }
+}
+```
+
+Both snippets work with **Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`), **Cursor** (`.cursor/mcp.json`), and any other MCP client that accepts the standard JSON configuration format.
 
 ## Tools
 This section provides a complete reference for the Postmark MCP server tools including example prompts and payloads. The server registers **24 tools** organized into eight categories.
@@ -177,7 +202,7 @@ This section provides a complete reference for the Postmark MCP server tools inc
 ## Email
 
 ### sendEmail
-Sends a single text (and optional HTML) email.
+Sends a transactional email to one recipient or up to 50 recipients.
 
 **Example Prompt:**
 ```
@@ -192,11 +217,14 @@ Send an email using Postmark to recipient@example.com with the subject "Meeting 
   "textBody": "Don't forget our team meeting tomorrow at 2 PM.",
   "htmlBody": "<p>Don't forget our team meeting tomorrow at 2 PM.</p>",
   "from": "sender@example.com",
+  "cc": "manager@example.com",
+  "bcc": "archive@example.com",
+  "replyTo": "support@example.com",
   "tag": "meetings"
 }
 ```
 
-`htmlBody`, `from`, and `tag` are optional. If `from` is omitted, `DEFAULT_SENDER_EMAIL` is used.
+`to` accepts a single address or an array of up to 50 addresses. `htmlBody`, `from`, `cc`, `bcc`, `replyTo`, and `tag` are optional. If `from` is omitted, `DEFAULT_SENDER_EMAIL` is used.
 
 **Response:**
 ```
@@ -309,7 +337,7 @@ Provide **either** `templateId` (number) **or** `templateAlias` (string). Top-le
 ## Templates
 
 ### listTemplates
-Lists all templates on the server.
+Lists saved templates on this server. Returns the first 100 templates; if a server has more than 100, pagination is not yet supported and the response will indicate that results are truncated.
 
 **Response:**
 ```
@@ -354,7 +382,7 @@ Updates an existing template. Requires `templateIdOrAlias` plus **at least one**
 Pass `"layoutTemplate": null` to unbind a template from its current Layout (the MCP translates this to the empty-string the Postmark API requires for clearing the association).
 
 ### deleteTemplate
-Deletes a template by ID or alias.
+Permanently deletes a template by ID or alias. Layout templates cannot be deleted while Standard templates are still bound to them — unbind via `editTemplate` first.
 
 **Payload:** `{ "templateIdOrAlias": "order-confirmation" }`
 

--- a/index.js
+++ b/index.js
@@ -28,12 +28,36 @@ let mcpClient = null; // { name: string, version: string|null }
 const logFile = process.env.LOG_FILE || null;
 const logEmailFull = process.env.LOG_EMAIL_FULL === 'true';
 
-// Optional comma-separated list of allowed webhook URL prefixes, e.g.
+// Optional comma-separated list of allowed webhook URL origins/prefixes, e.g.
 // WEBHOOK_URL_ALLOWLIST=https://hooks.example.com,https://inbound.myapp.io
-// When set, createWebhook rejects URLs that don't start with any listed prefix.
+// When set, createWebhook rejects URLs whose parsed origin+path don't match an entry.
 const webhookAllowlist = process.env.WEBHOOK_URL_ALLOWLIST
   ? process.env.WEBHOOK_URL_ALLOWLIST.split(',').map(s => s.trim()).filter(Boolean)
   : null;
+
+if (webhookAllowlist !== null && webhookAllowlist.length === 0) {
+  console.error('[WARN] WEBHOOK_URL_ALLOWLIST is set but parsed to an empty list — all webhook URLs will be rejected. Check for stray whitespace or commas.');
+}
+
+/**
+ * Checks whether a webhook URL is permitted by the allowlist.
+ * Matches on parsed origin + pathname prefix to prevent raw-string bypasses
+ * such as userinfo injection (https://allowed.host@evil.test/) or subdomain
+ * suffix spoofing (https://allowed.host.evil.test/).
+ * Returns true when no allowlist is configured (allow-all).
+ */
+function isAllowedWebhookUrl(url, allowlist) {
+  if (!allowlist) return true;
+  let u;
+  try { u = new URL(url); } catch { return false; }
+  // Reject embedded credentials — userinfo can be used to spoof host matching.
+  if (u.username || u.password) return false;
+  return allowlist.some(entry => {
+    let a;
+    try { a = new URL(entry); } catch { return false; }
+    return u.origin === a.origin && u.pathname.startsWith(a.pathname);
+  });
+}
 
 // MCP tool annotation presets (https://modelcontextprotocol.io/docs/concepts/tools)
 // Clients use these hints to decide whether to prompt for confirmation before invoking.
@@ -48,6 +72,12 @@ const DESTRUCTIVE = { readOnlyHint: false, destructiveHint: true,  idempotentHin
  * Message / ErrorCode. Returns parsed JSON (or null for empty 2xx bodies).
  */
 async function postmarkRequest(path, options = {}) {
+  // All internal callers pass a literal path starting with '/'. The absolute-URL
+  // branch is kept for flexibility, but anything else is a programming error and
+  // would be an SSRF footgun if user-influenced input ever reached this parameter.
+  if (!path.startsWith('/') && !path.startsWith('http')) {
+    throw new Error(`postmarkRequest: path must start with '/' or 'http', got: ${path}`);
+  }
   const url = path.startsWith('http') ? path : `${POSTMARK_API_BASE}${path}`;
   const headers = {
     Accept: 'application/json',
@@ -116,7 +146,11 @@ async function initializeServices() {
 
     // Verify connectivity + token by making a test API call.
     // Set POSTMARK_SKIP_VERIFY=true to bypass this check (e.g. in offline tests).
-    if (process.env.POSTMARK_SKIP_VERIFY !== 'true') {
+    if (process.env.POSTMARK_SKIP_VERIFY === 'true') {
+      if (serverToken !== 'POSTMARK_API_TEST') {
+        console.error('[WARN] POSTMARK_SKIP_VERIFY is enabled with a real server token — startup token verification is skipped. Do not use this in production.');
+      }
+    } else {
       await postmarkRequest('/server');
     }
 
@@ -496,7 +530,7 @@ function registerTools(server) {
       if (replyTo) emailData.ReplyTo = replyTo;
       if (tag) emailData.Tag = tag;
 
-      console.error('Sending template email..', { to, templateId: templateId || templateAlias });
+      console.error('Sending template email..', { templateId: templateId || templateAlias });
       const result = await postmarkRequest('/email/withTemplate', { method: 'POST', body: JSON.stringify(emailData) });
       if (result.ErrorCode !== 0) {
         throw new Error(`Postmark returned ErrorCode ${result.ErrorCode}: ${result.Message}`);
@@ -993,7 +1027,7 @@ function registerTools(server) {
       const windowFrom = fromDate || weekAgo;
       const windowTo = toDate || today;
 
-      console.error('Diagnosing delivery..', { recipient, messageId, stream });
+      console.error('Diagnosing delivery..', { messageId, stream });
 
       // Independent lookups in parallel — each tolerant of failure so a
       // single 404 (e.g., bad messageId) doesn't sink the whole diagnosis.
@@ -1445,7 +1479,7 @@ function registerTools(server) {
 
   server.tool(
     "createWebhook",
-    "Register a new Postmark webhook that will receive HTTP POST notifications when specified events occur (opens, clicks, bounces, etc.). Requires an HTTPS URL and at least one enabled trigger. Webhooks are persistent — Postmark will keep calling the URL until the webhook is deleted. Only register URLs you control.",
+    "Register a new Postmark webhook that will receive HTTP POST notifications when specified events occur (opens, clicks, bounces, etc.). Requires an HTTPS URL and at least one enabled trigger. Webhooks are persistent — Postmark will keep calling the URL until the webhook is deleted. Only register URLs you control. To secure the receiving endpoint, whitelist Postmark's published sending IPs at the network level.",
     {
       url: z.string().url().startsWith("https://").describe("The webhook URL to receive POST requests (must use HTTPS)"),
       messageStream: z.string().optional().describe("Message stream ID (e.g. 'outbound')"),
@@ -1464,10 +1498,10 @@ function registerTools(server) {
         throw new Error("At least one trigger must be enabled (openEnabled, clickEnabled, deliveryEnabled, bounceEnabled, spamComplaintEnabled, or subscriptionChangeEnabled)");
       }
 
-      if (webhookAllowlist && !webhookAllowlist.some(prefix => url.startsWith(prefix))) {
+      if (!isAllowedWebhookUrl(url, webhookAllowlist)) {
         throw new Error(
-          `Webhook URL rejected: does not match any allowed prefix in WEBHOOK_URL_ALLOWLIST. ` +
-          `Allowed prefixes: ${webhookAllowlist.join(', ')}`
+          `Webhook URL rejected: does not match any allowed origin in WEBHOOK_URL_ALLOWLIST. ` +
+          `Allowed entries: ${webhookAllowlist ? webhookAllowlist.join(', ') : '(none)'}`
         );
       }
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import { createRequire } from 'module';
-import { randomUUID } from 'crypto';
+import { appendFileSync } from 'fs';
 
 const require = createRequire(import.meta.url);
 const { version: clientVersion } = require('./package.json');
@@ -21,6 +21,25 @@ const REQUEST_TIMEOUT_MS = 60_000;
 const serverToken = process.env.POSTMARK_SERVER_TOKEN;
 const defaultSender = process.env.DEFAULT_SENDER_EMAIL;
 const defaultMessageStream = process.env.DEFAULT_MESSAGE_STREAM;
+const agentLabel = process.env.AGENT_LABEL || null;
+
+// Populated from the MCP initialize handshake once the client connects.
+let mcpClient = null; // { name: string, version: string|null }
+const logFile = process.env.LOG_FILE || null;
+const logEmailFull = process.env.LOG_EMAIL_FULL === 'true';
+
+// Optional comma-separated list of allowed webhook URL prefixes, e.g.
+// WEBHOOK_URL_ALLOWLIST=https://hooks.example.com,https://inbound.myapp.io
+// When set, createWebhook rejects URLs that don't start with any listed prefix.
+const webhookAllowlist = process.env.WEBHOOK_URL_ALLOWLIST
+  ? process.env.WEBHOOK_URL_ALLOWLIST.split(',').map(s => s.trim()).filter(Boolean)
+  : null;
+
+// MCP tool annotation presets (https://modelcontextprotocol.io/docs/concepts/tools)
+// Clients use these hints to decide whether to prompt for confirmation before invoking.
+const READ_ONLY  = { readOnlyHint: true,  destructiveHint: false, idempotentHint: true,  openWorldHint: true };
+const MUTATING   = { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true };
+const DESTRUCTIVE = { readOnlyHint: false, destructiveHint: true,  idempotentHint: false, openWorldHint: true };
 
 /**
  * Minimal hardened HTTP client for the Postmark REST API over native fetch.
@@ -35,7 +54,8 @@ async function postmarkRequest(path, options = {}) {
     'X-Postmark-Server-Token': serverToken,
     'X-Postmark-Client': 'postmark-mcp',
     'X-Postmark-Client-Version': clientVersion,
-    'X-Postmark-Correlation-Id': randomUUID(),
+    ...(mcpClient?.name && { 'X-Postmark-MCP-Client': [mcpClient.name, mcpClient.version].filter(Boolean).join('/') }),
+    ...(agentLabel && { 'X-Agent-Label': agentLabel }),
     ...options.headers,
   };
   if (options.body && !headers['Content-Type']) headers['Content-Type'] = 'application/json';
@@ -86,6 +106,7 @@ async function initializeServices() {
     console.error('Initializing Postmark MCP server..');
     console.error('Default sender: ', defaultSender);
     console.error('Message stream: ', defaultMessageStream);
+    if (agentLabel) console.error('Agent label: ', agentLabel);
 
     // Verify connectivity + token by making a test API call
     await postmarkRequest('/server');
@@ -114,6 +135,17 @@ async function main() {
 
     console.error('Connecting to MCP transport..');
     const transport = new StdioServerTransport();
+
+    // Capture MCP client identity from the initialize handshake.
+    // The SDK fires oninitialized after the client sends its `initialized` notification.
+    server.server.oninitialized = () => {
+      const cv = server.server.getClientVersion();
+      if (cv?.name) {
+        mcpClient = { name: cv.name, version: cv.version || null };
+        console.error('MCP client identified:', cv.name, cv.version || '');
+      }
+    };
+
     await server.connect(transport);
 
     console.error('Postmark MCP server is running and ready!');
@@ -317,8 +349,122 @@ const fmtStatResponse = (stat, d) => {
   }
 };
 
+// ───── Structured logging ──────────────────────────────────────────────────
+
+// Fields whose values are always replaced — match server tokens, passwords, etc.
+const REDACT_PATTERN = /password|secret|token|apikey|api_key/i;
+
+// Fields containing body/HTML content — truncated to a byte-count marker.
+const CONTENT_FIELDS = /htmlBody|textBody/i;
+
+// Any string over this length is truncated even if not a known content field.
+const MAX_STRING_LEN = 300;
+
+// Simple email detector — used to apply masking to email-like strings.
+const EMAIL_RE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
+
+/**
+ * Masks an email address, keeping the first and last chars of the mailbox
+ * and replacing the middle with asterisks. Domain is left in full.
+ * Examples:
+ *   user@example.com  → u**r@example.com
+ *   ab@example.com    → a*b@example.com
+ *   a@example.com     → a@example.com   (single char, nothing to mask)
+ *
+ * When LOG_EMAIL_FULL=true the original value is returned unchanged.
+ */
+function maskEmail(email) {
+  if (logEmailFull) return email;
+  const at = email.lastIndexOf('@');
+  if (at <= 0) return email;
+  const mailbox = email.slice(0, at);
+  const domain  = email.slice(at + 1);
+  if (mailbox.length <= 1) return email;
+  const stars  = '*'.repeat(Math.max(1, mailbox.length - 2));
+  const masked = mailbox[0] + stars + mailbox[mailbox.length - 1];
+  return `${masked}@${domain}`;
+}
+
+function sanitizeValue(key, value) {
+  if (REDACT_PATTERN.test(key)) return '[redacted]';
+  if (typeof value === 'string') {
+    if (CONTENT_FIELDS.test(key)) return `[${value.length}ch]`;
+    if (value.length > MAX_STRING_LEN) return `[truncated ${value.length}ch]`;
+    if (EMAIL_RE.test(value)) return maskEmail(value);
+    return value;
+  }
+  if (Array.isArray(value)) {
+    if (value.length === 0) return [];
+    // Message/recipient arrays — surface count + addressees, drop content
+    if (value[0] && typeof value[0] === 'object') {
+      const addrs = value
+        .map(m => m.to || m.email || m.EmailAddress)
+        .filter(Boolean)
+        .map(a => maskEmail(a));
+      return addrs.length
+        ? { _count: value.length, _recipients: addrs.slice(0, 20) }
+        : { _count: value.length };
+    }
+    // Primitive arrays (e.g. array of email strings)
+    const items = value.length <= 20 ? value : [...value.slice(0, 20), `…+${value.length - 20} more`];
+    return items.map(item => (typeof item === 'string' && EMAIL_RE.test(item)) ? maskEmail(item) : item);
+  }
+  // Arbitrary data objects (templateModel etc.) — show key names, not values
+  if (value && typeof value === 'object') return { _keys: Object.keys(value) };
+  return value;
+}
+
+function sanitizeArgs(args) {
+  if (!args || typeof args !== 'object') return {};
+  return Object.fromEntries(
+    Object.entries(args).map(([k, v]) => [k, sanitizeValue(k, v)])
+  );
+}
+
+function writeLog(entry) {
+  const line = JSON.stringify(entry);
+  process.stderr.write(line + '\n');
+  if (logFile) {
+    try {
+      appendFileSync(logFile, line + '\n');
+    } catch (e) {
+      process.stderr.write(JSON.stringify({
+        timestamp: new Date().toISOString(), level: 'warn',
+        message: `LOG_FILE write failed: ${e.message}`
+      }) + '\n');
+    }
+  }
+}
+
 // Tool registration
 function registerTools(server) {
+  // Transparently wrap every server.tool() call with structured logging.
+  // The original handler is replaced with one that emits a JSON log line on
+  // completion (or error), with sanitized args so no sensitive content leaks.
+  const _tool = server.tool.bind(server);
+  server.tool = (name, ...rest) => {
+    const handler = rest[rest.length - 1];
+    rest[rest.length - 1] = async (args) => {
+      const start = Date.now();
+      const base = {
+        timestamp: new Date().toISOString(),
+        tool: name,
+        clientName: mcpClient?.name ?? null,
+        clientVersion: mcpClient?.version ?? null,
+        args: sanitizeArgs(args),
+      };
+      try {
+        const result = await handler(args);
+        writeLog({ ...base, status: 'ok', durationMs: Date.now() - start });
+        return result;
+      } catch (err) {
+        writeLog({ ...base, status: 'error', error: err.message, durationMs: Date.now() - start });
+        throw err;
+      }
+    };
+    return _tool(name, ...rest);
+  };
+
   // ─────────────── Email ───────────────
 
   server.tool(
@@ -331,6 +477,7 @@ function registerTools(server) {
       from: z.string().email().optional().describe("Sender email address (optional, uses default if not provided)"),
       tag: z.string().optional().describe("Optional tag for categorization")
     },
+    MUTATING,
     async ({ to, subject, textBody, htmlBody, from, tag }) => {
       const emailData = {
         From: from || defaultSender,
@@ -371,6 +518,7 @@ function registerTools(server) {
       from: z.string().email().optional().describe("Sender email address (optional)"),
       tag: z.string().optional().describe("Optional tag for categorization")
     },
+    MUTATING,
     async ({ to, templateId, templateAlias, templateModel, from, tag }) => {
       if (!templateId && !templateAlias) {
         throw new Error("Either templateId or templateAlias must be provided");
@@ -455,6 +603,7 @@ function registerTools(server) {
         tag: z.string().optional().describe("Tag for categorization")
       })).min(1).max(500).describe("Up to 500 messages to send in a single request")
     },
+    MUTATING,
     async ({ messages }) => {
       const payload = messages.map(m => {
         const msg = {
@@ -500,6 +649,7 @@ function registerTools(server) {
         tag: z.string().optional().describe("Override tag for this recipient")
       })).min(1).max(500).describe("Up to 500 recipients, each with their own template model")
     },
+    MUTATING,
     async ({ templateId, templateAlias, from, tag, recipients }) => {
       if (!templateId && !templateAlias) {
         throw new Error("Either templateId or templateAlias must be provided");
@@ -541,6 +691,7 @@ function registerTools(server) {
   server.tool(
     "listTemplates",
     {},
+    READ_ONLY,
     async () => {
       console.error('Fetching templates..');
       const result = await postmarkRequest(`/templates${qs({ count: 100, offset: 0 })}`);
@@ -572,6 +723,7 @@ function registerTools(server) {
     {
       templateIdOrAlias: z.union([z.number(), z.string()]).describe("Template ID (number) or alias (string)")
     },
+    READ_ONLY,
     async ({ templateIdOrAlias }) => {
       console.error('Fetching template..', { templateIdOrAlias });
       const result = await postmarkRequest(`/templates/${encodeURIComponent(templateIdOrAlias)}`);
@@ -606,6 +758,7 @@ function registerTools(server) {
       templateType: z.enum(["Standard", "Layout"]).optional().describe("Template type (default: Standard)"),
       layoutTemplate: z.string().optional().describe("Alias of an existing Layout template to wrap this template's content. Only valid when templateType is 'Standard' (the default).")
     },
+    MUTATING,
     async ({ name, subject, htmlBody, textBody, alias, templateType, layoutTemplate }) => {
       if (!htmlBody && !textBody) {
         throw new Error("At least one of htmlBody or textBody must be provided");
@@ -658,6 +811,7 @@ function registerTools(server) {
       alias: z.string().optional().describe("Updated alias"),
       layoutTemplate: z.string().nullable().optional().describe("Alias of a Layout template to bind this Standard template to. Pass null to unbind (remove the layout association).")
     },
+    DESTRUCTIVE,
     async ({ templateIdOrAlias, name, subject, htmlBody, textBody, alias, layoutTemplate }) => {
       const options = {};
       if (name) options.Name = name;
@@ -698,6 +852,7 @@ function registerTools(server) {
     {
       templateIdOrAlias: z.union([z.number(), z.string()]).describe("Template ID (number) or alias (string) to delete")
     },
+    DESTRUCTIVE,
     async ({ templateIdOrAlias }) => {
       console.error('Deleting template..', { templateIdOrAlias });
       await postmarkRequest(`/templates/${encodeURIComponent(templateIdOrAlias)}`, { method: 'DELETE' });
@@ -722,6 +877,7 @@ function registerTools(server) {
       templateType: z.enum(["Standard", "Layout"]).optional().describe("Template type (default: Standard)"),
       layoutTemplate: z.string().optional().describe("Layout template alias to validate against")
     },
+    READ_ONLY,
     async ({ subject, htmlBody, textBody, testRenderModel, templateType, layoutTemplate }) => {
       if (!subject && !htmlBody && !textBody) {
         throw new Error("At least one of subject, htmlBody, or textBody must be provided");
@@ -782,6 +938,7 @@ function registerTools(server) {
       count: z.number().int().min(1).max(500).optional().describe("Number of results to return (default 50, max 500)"),
       offset: z.number().int().min(0).optional().describe("Pagination offset (default 0)")
     },
+    READ_ONLY,
     async ({ recipient, fromEmail, tag, subject, status, messageStream, fromDate, toDate, count, offset }) => {
       const filter = {};
       if (recipient) filter.recipient = recipient;
@@ -821,6 +978,7 @@ function registerTools(server) {
     {
       messageId: z.string().describe("The MessageID of the email to retrieve details for")
     },
+    READ_ONLY,
     async ({ messageId }) => {
       console.error('Fetching message details..', { messageId });
       const result = await postmarkRequest(`/messages/outbound/${encodeURIComponent(messageId)}/details`);
@@ -860,6 +1018,7 @@ function registerTools(server) {
       toDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional().describe("Search window end, YYYY-MM-DD (default: today)"),
       messageStream: z.string().optional().describe("Message stream for suppression check (default: DEFAULT_MESSAGE_STREAM)")
     },
+    READ_ONLY,
     async ({ recipient, messageId, fromDate, toDate, messageStream }) => {
       const stream = messageStream || defaultMessageStream;
       const today = new Date().toISOString().slice(0, 10);
@@ -997,6 +1156,7 @@ function registerTools(server) {
       count: z.number().int().min(1).max(500).optional().describe("Number of results (default 50, max 500)"),
       offset: z.number().int().min(0).optional().describe("Pagination offset (default 0)")
     },
+    READ_ONLY,
     async ({ type, inactive, emailFilter, tag, messageID, messageStream, fromDate, toDate, count, offset }) => {
       const filter = {};
       if (type) filter.type = type;
@@ -1036,6 +1196,7 @@ function registerTools(server) {
     {
       bounceId: z.number().int().describe("The ID of the bounce to retrieve the SMTP dump for")
     },
+    READ_ONLY,
     async ({ bounceId }) => {
       console.error('Fetching bounce dump..', { bounceId });
       const result = await postmarkRequest(`/bounces/${encodeURIComponent(bounceId)}/dump`);
@@ -1057,6 +1218,7 @@ function registerTools(server) {
     {
       bounceId: z.number().int().describe("The ID of the bounce to reactivate")
     },
+    MUTATING,
     async ({ bounceId }) => {
       console.error('Activating bounce..', { bounceId });
       const result = await postmarkRequest(`/bounces/${encodeURIComponent(bounceId)}/activate`, { method: 'PUT' });
@@ -1086,6 +1248,7 @@ function registerTools(server) {
       fromDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional().describe("Start date in YYYY-MM-DD format"),
       toDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional().describe("End date in YYYY-MM-DD format")
     },
+    READ_ONLY,
     async ({ messageStream, suppressionReason, origin, emailAddress, fromDate, toDate }) => {
       const stream = messageStream || defaultMessageStream;
       const filter = {};
@@ -1122,6 +1285,7 @@ function registerTools(server) {
       emailAddresses: z.array(z.string().email()).min(1).max(50).describe("Email addresses to suppress (max 50)"),
       messageStream: z.string().optional().describe("Message stream ID (default: DEFAULT_MESSAGE_STREAM)")
     },
+    MUTATING,
     async ({ emailAddresses, messageStream }) => {
       const stream = messageStream || defaultMessageStream;
       const options = {
@@ -1151,6 +1315,7 @@ function registerTools(server) {
       emailAddresses: z.array(z.string().email()).min(1).max(50).describe("Email addresses to unsuppress (max 50). Note: SpamComplaint suppressions cannot be deleted."),
       messageStream: z.string().optional().describe("Message stream ID (default: DEFAULT_MESSAGE_STREAM)")
     },
+    DESTRUCTIVE,
     async ({ emailAddresses, messageStream }) => {
       const stream = messageStream || defaultMessageStream;
       const options = {
@@ -1189,6 +1354,7 @@ function registerTools(server) {
       toDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional().describe("End date in YYYY-MM-DD format"),
       messageStream: z.string().optional().describe("Filter by message stream ID")
     },
+    READ_ONLY,
     async ({ stat, tag, fromDate, toDate, messageStream }) => {
       const filter = {};
       if (tag) filter.tag = tag;
@@ -1230,6 +1396,7 @@ function registerTools(server) {
   server.tool(
     "getServerInfo",
     {},
+    READ_ONLY,
     async () => {
       console.error('Fetching server info..');
       const result = await postmarkRequest('/server');
@@ -1266,6 +1433,7 @@ function registerTools(server) {
     {
       messageStream: z.string().optional().describe("Filter by message stream ID (e.g. 'outbound')")
     },
+    READ_ONLY,
     async ({ messageStream }) => {
       const filter = {};
       if (messageStream) filter.messagestream = messageStream;
@@ -1302,7 +1470,7 @@ function registerTools(server) {
   server.tool(
     "createWebhook",
     {
-      url: z.string().url().describe("The webhook URL to receive POST requests"),
+      url: z.string().url().startsWith("https://").describe("The webhook URL to receive POST requests (must use HTTPS)"),
       messageStream: z.string().optional().describe("Message stream ID (e.g. 'outbound')"),
       openEnabled: z.boolean().optional().describe("Trigger on email opens"),
       clickEnabled: z.boolean().optional().describe("Trigger on link clicks"),
@@ -1311,11 +1479,19 @@ function registerTools(server) {
       spamComplaintEnabled: z.boolean().optional().describe("Trigger on spam complaints"),
       subscriptionChangeEnabled: z.boolean().optional().describe("Trigger on subscription changes")
     },
+    MUTATING,
     async ({ url, messageStream, openEnabled, clickEnabled, deliveryEnabled, bounceEnabled, spamComplaintEnabled, subscriptionChangeEnabled }) => {
       const anyTrigger = openEnabled || clickEnabled || deliveryEnabled ||
         bounceEnabled || spamComplaintEnabled || subscriptionChangeEnabled;
       if (!anyTrigger) {
         throw new Error("At least one trigger must be enabled (openEnabled, clickEnabled, deliveryEnabled, bounceEnabled, spamComplaintEnabled, or subscriptionChangeEnabled)");
+      }
+
+      if (webhookAllowlist && !webhookAllowlist.some(prefix => url.startsWith(prefix))) {
+        throw new Error(
+          `Webhook URL rejected: does not match any allowed prefix in WEBHOOK_URL_ALLOWLIST. ` +
+          `Allowed prefixes: ${webhookAllowlist.join(', ')}`
+        );
       }
 
       const options = {
@@ -1362,6 +1538,7 @@ function registerTools(server) {
     {
       webhookId: z.number().int().describe("The ID of the webhook to delete")
     },
+    DESTRUCTIVE,
     async ({ webhookId }) => {
       console.error('Deleting webhook..', { webhookId });
       await postmarkRequest(`/webhooks/${encodeURIComponent(webhookId)}`, { method: 'DELETE' });

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import { createRequire } from 'module';
-import { appendFileSync } from 'fs';
+import { createLogger } from './lib/log.js';
 
 const require = createRequire(import.meta.url);
 const { version: clientVersion } = require('./package.json');
@@ -108,8 +108,11 @@ async function initializeServices() {
     console.error('Message stream: ', defaultMessageStream);
     if (agentLabel) console.error('Agent label: ', agentLabel);
 
-    // Verify connectivity + token by making a test API call
-    await postmarkRequest('/server');
+    // Verify connectivity + token by making a test API call.
+    // Set POSTMARK_SKIP_VERIFY=true to bypass this check (e.g. in offline tests).
+    if (process.env.POSTMARK_SKIP_VERIFY !== 'true') {
+      await postmarkRequest('/server');
+    }
 
     const mcpServer = new McpServer({
       name: "postmark-mcp",
@@ -351,90 +354,7 @@ const fmtStatResponse = (stat, d) => {
 
 // ───── Structured logging ──────────────────────────────────────────────────
 
-// Fields whose values are always replaced — match server tokens, passwords, etc.
-const REDACT_PATTERN = /password|secret|token|apikey|api_key/i;
-
-// Fields containing body/HTML content — truncated to a byte-count marker.
-const CONTENT_FIELDS = /htmlBody|textBody/i;
-
-// Any string over this length is truncated even if not a known content field.
-const MAX_STRING_LEN = 300;
-
-// Simple email detector — used to apply masking to email-like strings.
-const EMAIL_RE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
-
-/**
- * Masks an email address, keeping the first and last chars of the mailbox
- * and replacing the middle with asterisks. Domain is left in full.
- * Examples:
- *   user@example.com  → u**r@example.com
- *   ab@example.com    → a*b@example.com
- *   a@example.com     → a@example.com   (single char, nothing to mask)
- *
- * When LOG_EMAIL_FULL=true the original value is returned unchanged.
- */
-function maskEmail(email) {
-  if (logEmailFull) return email;
-  const at = email.lastIndexOf('@');
-  if (at <= 0) return email;
-  const mailbox = email.slice(0, at);
-  const domain  = email.slice(at + 1);
-  if (mailbox.length <= 1) return email;
-  const stars  = '*'.repeat(Math.max(1, mailbox.length - 2));
-  const masked = mailbox[0] + stars + mailbox[mailbox.length - 1];
-  return `${masked}@${domain}`;
-}
-
-function sanitizeValue(key, value) {
-  if (REDACT_PATTERN.test(key)) return '[redacted]';
-  if (typeof value === 'string') {
-    if (CONTENT_FIELDS.test(key)) return `[${value.length}ch]`;
-    if (value.length > MAX_STRING_LEN) return `[truncated ${value.length}ch]`;
-    if (EMAIL_RE.test(value)) return maskEmail(value);
-    return value;
-  }
-  if (Array.isArray(value)) {
-    if (value.length === 0) return [];
-    // Message/recipient arrays — surface count + addressees, drop content
-    if (value[0] && typeof value[0] === 'object') {
-      const addrs = value
-        .map(m => m.to || m.email || m.EmailAddress)
-        .filter(Boolean)
-        .map(a => maskEmail(a));
-      return addrs.length
-        ? { _count: value.length, _recipients: addrs.slice(0, 20) }
-        : { _count: value.length };
-    }
-    // Primitive arrays (e.g. array of email strings)
-    const items = value.length <= 20 ? value : [...value.slice(0, 20), `…+${value.length - 20} more`];
-    return items.map(item => (typeof item === 'string' && EMAIL_RE.test(item)) ? maskEmail(item) : item);
-  }
-  // Arbitrary data objects (templateModel etc.) — show key names, not values
-  if (value && typeof value === 'object') return { _keys: Object.keys(value) };
-  return value;
-}
-
-function sanitizeArgs(args) {
-  if (!args || typeof args !== 'object') return {};
-  return Object.fromEntries(
-    Object.entries(args).map(([k, v]) => [k, sanitizeValue(k, v)])
-  );
-}
-
-function writeLog(entry) {
-  const line = JSON.stringify(entry);
-  process.stderr.write(line + '\n');
-  if (logFile) {
-    try {
-      appendFileSync(logFile, line + '\n');
-    } catch (e) {
-      process.stderr.write(JSON.stringify({
-        timestamp: new Date().toISOString(), level: 'warn',
-        message: `LOG_FILE write failed: ${e.message}`
-      }) + '\n');
-    }
-  }
-}
+const { maskEmail, sanitizeArgs, writeLog } = createLogger({ emailFull: logEmailFull, logFile });
 
 // Tool registration
 function registerTools(server) {

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ const DESTRUCTIVE = { readOnlyHint: false, destructiveHint: true,  idempotentHin
 
 /**
  * Minimal hardened HTTP client for the Postmark REST API over native fetch.
- * Stamps client identity + correlation headers, enforces a request timeout,
+ * Stamps client identity headers, enforces a request timeout,
  * and maps non-2xx responses to Error objects that surface Postmark's
  * Message / ErrorCode. Returns parsed JSON (or null for empty 2xx bodies).
  */
@@ -438,7 +438,6 @@ function registerTools(server) {
       if (replyTo) emailData.ReplyTo = replyTo;
       if (tag) emailData.Tag = tag;
 
-      console.error('Sending email..', { to, subject });
       const result = await postmarkRequest('/email', { method: 'POST', body: JSON.stringify(emailData) });
       if (result.ErrorCode !== 0) {
         throw new Error(`Postmark returned ErrorCode ${result.ErrorCode}: ${result.Message}`);

--- a/index.js
+++ b/index.js
@@ -89,17 +89,23 @@ function qs(params) {
 async function initializeServices() {
   try {
     if (!serverToken) {
-      console.error('[ERROR] POSTMARK_SERVER_TOKEN is not set');
+      console.error('[ERROR] POSTMARK_SERVER_TOKEN is not set.');
+      console.error('  → Find your Server Token at: https://account.postmarkapp.com → your server → API Tokens tab');
+      console.error('  → Set it in your .env file or pass it via the env block in your MCP client config.');
       process.exit(1);
     }
 
     if (!defaultSender) {
-      console.error('[ERROR] DEFAULT_SENDER_EMAIL is not set');
+      console.error('[ERROR] DEFAULT_SENDER_EMAIL is not set.');
+      console.error('  → This must be an email address with a verified Sender Signature in Postmark.');
+      console.error('  → Manage sender signatures at: https://account.postmarkapp.com/signature_domains');
       process.exit(1);
     }
 
     if (!defaultMessageStream) {
-      console.error('[ERROR] DEFAULT_MESSAGE_STREAM is not set');
+      console.error('[ERROR] DEFAULT_MESSAGE_STREAM is not set.');
+      console.error('  → Set this to your outbound message stream ID (typically "outbound").');
+      console.error('  → View streams at: https://account.postmarkapp.com → your server → Message Streams');
       process.exit(1);
     }
 
@@ -121,11 +127,21 @@ async function initializeServices() {
 
     return { mcpServer };
   } catch (error) {
-    if (error.code || error.message) {
-      throw new Error(`Initialization failed: ${error.code ? `${error.code} - ` : ''}${error.message}`);
+    const msg = error.message || '';
+    if (msg.includes('401') || msg.toLowerCase().includes('unauthorized') || msg.includes('ErrorCode 10')) {
+      throw new Error(
+        `Initialization failed: Postmark rejected the server token (401 Unauthorized).\n` +
+        `  → Verify POSTMARK_SERVER_TOKEN is correct and belongs to a Server Token (not an Account Token).\n` +
+        `  → https://account.postmarkapp.com → your server → API Tokens tab`
+      );
     }
-
-    throw new Error('Initialization failed: An unexpected error occurred');
+    if (error.cause?.code === 'ENOTFOUND' || msg.includes('fetch failed') || msg.includes('ENOTFOUND')) {
+      throw new Error(
+        `Initialization failed: Could not reach the Postmark API (${msg}).\n` +
+        `  → Check your internet connection and that https://api.postmarkapp.com is reachable.`
+      );
+    }
+    throw new Error(`Initialization failed: ${error.code ? `${error.code} - ` : ''}${msg || 'An unexpected error occurred'}`);
   }
 }
 
@@ -389,19 +405,26 @@ function registerTools(server) {
 
   server.tool(
     "sendEmail",
+    "Send a single transactional email via Postmark. Accepts one recipient or an array of up to 50. The From address must be a verified sender signature. Open and link tracking are enabled automatically. Use sendBatch to send multiple distinct messages in one call.",
     {
-      to: z.string().email().describe("Recipient email address"),
+      to: z.union([
+        z.string().email(),
+        z.array(z.string().email()).min(1).max(50),
+      ]).describe("Recipient email address, or an array of up to 50 addresses"),
       subject: z.string().describe("Email subject"),
       textBody: z.string().describe("Plain text body of the email"),
       htmlBody: z.string().optional().describe("HTML body of the email (optional)"),
       from: z.string().email().optional().describe("Sender email address (optional, uses default if not provided)"),
+      cc: z.string().optional().describe("CC recipient(s), comma-separated (optional)"),
+      bcc: z.string().optional().describe("BCC recipient(s), comma-separated (optional)"),
+      replyTo: z.string().email().optional().describe("Reply-To address (optional)"),
       tag: z.string().optional().describe("Optional tag for categorization")
     },
     MUTATING,
-    async ({ to, subject, textBody, htmlBody, from, tag }) => {
+    async ({ to, subject, textBody, htmlBody, from, cc, bcc, replyTo, tag }) => {
       const emailData = {
         From: from || defaultSender,
-        To: to,
+        To: Array.isArray(to) ? to.join(', ') : to,
         Subject: subject,
         TextBody: textBody,
         MessageStream: defaultMessageStream,
@@ -410,6 +433,9 @@ function registerTools(server) {
       };
 
       if (htmlBody) emailData.HtmlBody = htmlBody;
+      if (cc) emailData.Cc = cc;
+      if (bcc) emailData.Bcc = bcc;
+      if (replyTo) emailData.ReplyTo = replyTo;
       if (tag) emailData.Tag = tag;
 
       console.error('Sending email..', { to, subject });
@@ -430,18 +456,25 @@ function registerTools(server) {
 
   server.tool(
     "sendEmailWithTemplate",
+    "Send a single email rendered from a saved Postmark template. Supply either templateId (numeric) or templateAlias (string) plus a templateModel object that provides the template variables. The From address must be a verified sender signature.",
     {
       to: z.string().email().describe("Recipient email address"),
-      templateId: z.number().optional().describe("Template ID (use either this or templateAlias)"),
-      templateAlias: z.string().optional().describe("Template alias (use either this or templateId)"),
+      templateId: z.number().optional().describe("Template ID — provide either this or templateAlias, not both"),
+      templateAlias: z.string().optional().describe("Template alias — provide either this or templateId, not both"),
       templateModel: z.object({}).passthrough().describe("Data model for template variables"),
       from: z.string().email().optional().describe("Sender email address (optional)"),
+      cc: z.string().optional().describe("CC recipient(s), comma-separated (optional)"),
+      bcc: z.string().optional().describe("BCC recipient(s), comma-separated (optional)"),
+      replyTo: z.string().email().optional().describe("Reply-To address (optional)"),
       tag: z.string().optional().describe("Optional tag for categorization")
     },
     MUTATING,
-    async ({ to, templateId, templateAlias, templateModel, from, tag }) => {
+    async ({ to, templateId, templateAlias, templateModel, from, cc, bcc, replyTo, tag }) => {
       if (!templateId && !templateAlias) {
         throw new Error("Either templateId or templateAlias must be provided");
+      }
+      if (templateId && templateAlias) {
+        throw new Error("Provide only one of templateId or templateAlias, not both");
       }
 
       const emailData = {
@@ -459,6 +492,9 @@ function registerTools(server) {
         emailData.TemplateAlias = templateAlias;
       }
 
+      if (cc) emailData.Cc = cc;
+      if (bcc) emailData.Bcc = bcc;
+      if (replyTo) emailData.ReplyTo = replyTo;
       if (tag) emailData.Tag = tag;
 
       console.error('Sending template email..', { to, templateId: templateId || templateAlias });
@@ -510,6 +546,7 @@ function registerTools(server) {
 
   server.tool(
     "sendBatch",
+    "Send up to 500 independent emails in a single synchronous Postmark API call (POST /email/batch). Each message has its own recipient, subject, and body. Returns per-message results — the overall HTTP call succeeds even when individual messages fail. Use sendEmail for a single message.",
     {
       messages: z.array(z.object({
         to: z.string().email().describe("Recipient email address"),
@@ -554,6 +591,7 @@ function registerTools(server) {
 
   server.tool(
     "sendBatchWithTemplate",
+    "Send the same Postmark template to up to 500 recipients in a single call, with per-recipient template models (POST /email/batchWithTemplates). Supply either templateId or templateAlias. Returns per-message results. Use sendEmailWithTemplate for a single recipient.",
     {
       templateId: z.number().int().optional().describe("Template ID (use either this or templateAlias)"),
       templateAlias: z.string().optional().describe("Template alias (use either this or templateId)"),
@@ -610,6 +648,7 @@ function registerTools(server) {
 
   server.tool(
     "listTemplates",
+    "List saved email templates on this Postmark server. Returns up to 100 templates with name, ID, alias, subject, type (Standard or Layout), and layout binding. Use getTemplate to retrieve a template's full HTML and text content.",
     {},
     READ_ONLY,
     async () => {
@@ -629,10 +668,11 @@ function registerTools(server) {
         return lines.join('\n');
       }).join('\n\n');
 
+      const truncated = result.Templates.length === 100;
       return {
         content: [{
           type: "text",
-          text: `Found ${result.Templates.length} templates:\n\n${templateList}`
+          text: `Found ${result.Templates.length} templates${truncated ? ' (first 100 shown — server may have more; pagination not yet supported)' : ''}:\n\n${templateList}`
         }]
       };
     }
@@ -640,6 +680,7 @@ function registerTools(server) {
 
   server.tool(
     "getTemplate",
+    "Retrieve the full content of a single Postmark template — HTML body, text body, subject, type (Standard/Layout), and layout association — by numeric ID or string alias.",
     {
       templateIdOrAlias: z.union([z.number(), z.string()]).describe("Template ID (number) or alias (string)")
     },
@@ -669,6 +710,7 @@ function registerTools(server) {
 
   server.tool(
     "createTemplate",
+    "Create a new email template on this Postmark server. Requires a name and at least one of htmlBody or textBody. Subject is required for Standard templates and must be omitted for Layout templates. Optionally bind a Standard template to an existing Layout via layoutTemplate.",
     {
       name: z.string().describe("Template name"),
       subject: z.string().optional().describe("Template subject line. Required for Standard templates; must be omitted for Layout templates (Postmark rejects Subject on Layouts)."),
@@ -722,6 +764,7 @@ function registerTools(server) {
 
   server.tool(
     "editTemplate",
+    "Update an existing Postmark template's name, subject, HTML body, text body, alias, or layout binding. At least one field must be provided. Overwrites existing content in place — this cannot be undone. Pass layoutTemplate: null to detach a Standard template from its Layout.",
     {
       templateIdOrAlias: z.union([z.number(), z.string()]).describe("Template ID (number) or alias (string)"),
       name: z.string().optional().describe("Updated template name"),
@@ -769,6 +812,7 @@ function registerTools(server) {
 
   server.tool(
     "deleteTemplate",
+    "Permanently delete a Postmark template by numeric ID or string alias. This cannot be undone. Layout templates cannot be deleted while Standard templates are still bound to them.",
     {
       templateIdOrAlias: z.union([z.number(), z.string()]).describe("Template ID (number) or alias (string) to delete")
     },
@@ -789,6 +833,7 @@ function registerTools(server) {
 
   server.tool(
     "validateTemplate",
+    "Validate Postmark Mustachio template syntax and variable references without saving anything. Checks subject, HTML body, and/or text body for errors and optionally renders them against a test data model. Use this before createTemplate or editTemplate to catch mistakes early.",
     {
       subject: z.string().optional().describe("Template subject to validate"),
       htmlBody: z.string().optional().describe("HTML body to validate"),
@@ -846,6 +891,7 @@ function registerTools(server) {
 
   server.tool(
     "searchOutboundMessages",
+    "Search outbound message history on this Postmark server. Filter by recipient, sender, subject, tag, delivery status, message stream, or date range. Returns up to 500 messages per call with basic metadata. Use getMessageDetails to retrieve the full event timeline for a specific message.",
     {
       recipient: z.string().optional().describe("Filter by recipient email address"),
       fromEmail: z.string().optional().describe("Filter by sender email address"),
@@ -856,7 +902,7 @@ function registerTools(server) {
       fromDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional().describe("Start date in YYYY-MM-DD format"),
       toDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional().describe("End date in YYYY-MM-DD format"),
       count: z.number().int().min(1).max(500).optional().describe("Number of results to return (default 50, max 500)"),
-      offset: z.number().int().min(0).optional().describe("Pagination offset (default 0)")
+      offset: z.number().int().min(0).optional().describe("Pagination offset (default 0). Note: count + offset cannot exceed 10,000.")
     },
     READ_ONLY,
     async ({ recipient, fromEmail, tag, subject, status, messageStream, fromDate, toDate, count, offset }) => {
@@ -895,6 +941,7 @@ function registerTools(server) {
 
   server.tool(
     "getMessageDetails",
+    "Retrieve the full delivery details and event timeline (Delivered, Opened, Clicked, Bounced, etc.) for a single outbound message by its Postmark MessageID. Use searchOutboundMessages to find a MessageID first.",
     {
       messageId: z.string().describe("The MessageID of the email to retrieve details for")
     },
@@ -931,6 +978,7 @@ function registerTools(server) {
   // by running searches/lookups in parallel and synthesizing a recommendation.
   server.tool(
     "diagnoseDelivery",
+    "Diagnose why an email may not have reached a recipient. Runs message search, suppression lookup, and bounce history checks in parallel and returns a plain-English recommendation. Use this as a first step when a recipient reports a missing, undelivered, or bounced email.",
     {
       recipient: z.string().email().describe("The recipient address to investigate"),
       messageId: z.string().optional().describe("Optional specific MessageID to investigate. If omitted, the most recent message to recipient is used"),
@@ -1057,6 +1105,7 @@ function registerTools(server) {
 
   server.tool(
     "searchBounces",
+    "Search the Postmark bounce log. Filter by bounce type, email address, tag, message ID, message stream, and date range. Returns bounce records with type, description, timestamp, and whether each address can be reactivated. Bounce records are retained for 45 days.",
     {
       type: z.enum([
         "AddressChange", "AutoResponder", "BadEmailAddress", "Blocked",
@@ -1074,7 +1123,7 @@ function registerTools(server) {
       fromDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional().describe("Start date in YYYY-MM-DD format"),
       toDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional().describe("End date in YYYY-MM-DD format"),
       count: z.number().int().min(1).max(500).optional().describe("Number of results (default 50, max 500)"),
-      offset: z.number().int().min(0).optional().describe("Pagination offset (default 0)")
+      offset: z.number().int().min(0).optional().describe("Pagination offset (default 0). Note: count + offset cannot exceed 10,000.")
     },
     READ_ONLY,
     async ({ type, inactive, emailFilter, tag, messageID, messageStream, fromDate, toDate, count, offset }) => {
@@ -1113,6 +1162,7 @@ function registerTools(server) {
 
   server.tool(
     "getBounceDump",
+    "Retrieve the raw SMTP conversation transcript for a specific bounce record. Useful for diagnosing exactly how a remote mail server rejected a message. Dumps are only retained for 30 days after the bounce.",
     {
       bounceId: z.number().int().describe("The ID of the bounce to retrieve the SMTP dump for")
     },
@@ -1135,6 +1185,7 @@ function registerTools(server) {
 
   server.tool(
     "activateBounce",
+    "Reactivate a deactivated email address so it can receive mail again on Postmark. Only works on bounces where CanActivate is true (typically HardBounce). SpamComplaint bounces cannot be reactivated. Use searchBounces or diagnoseDelivery to find the bounceId.",
     {
       bounceId: z.number().int().describe("The ID of the bounce to reactivate")
     },
@@ -1160,6 +1211,7 @@ function registerTools(server) {
 
   server.tool(
     "listSuppressions",
+    "List suppressed email addresses on a Postmark message stream. Optionally filter by suppression reason (HardBounce, SpamComplaint, ManualSuppression), origin (Recipient, Customer, Admin), email address, or date range. Suppressed addresses will not receive mail on that stream.",
     {
       messageStream: z.string().optional().describe("Message stream ID (default: DEFAULT_MESSAGE_STREAM)"),
       suppressionReason: z.enum(["HardBounce", "SpamComplaint", "ManualSuppression"]).optional().describe("Filter by suppression reason"),
@@ -1201,6 +1253,7 @@ function registerTools(server) {
 
   server.tool(
     "createSuppressions",
+    "Add up to 50 email addresses to the suppression list for a Postmark message stream. Suppressed addresses will not receive mail on that stream. Each address in the response indicates whether suppression was created or failed.",
     {
       emailAddresses: z.array(z.string().email()).min(1).max(50).describe("Email addresses to suppress (max 50)"),
       messageStream: z.string().optional().describe("Message stream ID (default: DEFAULT_MESSAGE_STREAM)")
@@ -1231,6 +1284,7 @@ function registerTools(server) {
 
   server.tool(
     "deleteSuppressions",
+    "Remove up to 50 addresses from the suppression list on a Postmark message stream, allowing them to receive mail again. SpamComplaint suppressions cannot be deleted via API. Deleting a HardBounce suppression is equivalent to reactivating that bounce.",
     {
       emailAddresses: z.array(z.string().email()).min(1).max(50).describe("Email addresses to unsuppress (max 50). Note: SpamComplaint suppressions cannot be deleted."),
       messageStream: z.string().optional().describe("Message stream ID (default: DEFAULT_MESSAGE_STREAM)")
@@ -1263,6 +1317,7 @@ function registerTools(server) {
 
   server.tool(
     "getDeliveryStats",
+    "Retrieve outbound email statistics for this Postmark server. The default 'summary' stat returns headline open rate, click rate, bounce rate, and spam rate. Specify a stat value (opens, clicks, bounces, openPlatforms, etc.) for a focused breakdown. Filterable by tag, date range, and message stream.",
     {
       stat: z.enum([
         "summary", "overview", "sent", "bounces", "spam", "tracked",
@@ -1315,6 +1370,7 @@ function registerTools(server) {
 
   server.tool(
     "getServerInfo",
+    "Retrieve this Postmark server's configuration: name, ID, color, SMTP activation status, inbound address, open and link tracking settings, and any legacy server-level webhook URLs. Use listWebhooks for webhooks managed via the Webhooks API.",
     {},
     READ_ONLY,
     async () => {
@@ -1350,6 +1406,7 @@ function registerTools(server) {
 
   server.tool(
     "listWebhooks",
+    "List all webhooks configured on this Postmark server via the Webhooks API. Optionally filter by message stream. Shows each webhook's URL, numeric ID, stream, and enabled event triggers. Use the ID with deleteWebhook to remove one.",
     {
       messageStream: z.string().optional().describe("Filter by message stream ID (e.g. 'outbound')")
     },
@@ -1389,6 +1446,7 @@ function registerTools(server) {
 
   server.tool(
     "createWebhook",
+    "Register a new Postmark webhook that will receive HTTP POST notifications when specified events occur (opens, clicks, bounces, etc.). Requires an HTTPS URL and at least one enabled trigger. Webhooks are persistent — Postmark will keep calling the URL until the webhook is deleted. Only register URLs you control.",
     {
       url: z.string().url().startsWith("https://").describe("The webhook URL to receive POST requests (must use HTTPS)"),
       messageStream: z.string().optional().describe("Message stream ID (e.g. 'outbound')"),
@@ -1455,6 +1513,7 @@ function registerTools(server) {
 
   server.tool(
     "deleteWebhook",
+    "Permanently delete a Postmark webhook by its numeric ID. Postmark will stop sending event notifications to that URL immediately. Use listWebhooks to find the ID.",
     {
       webhookId: z.number().int().describe("The ID of the webhook to delete")
     },

--- a/lib/log.js
+++ b/lib/log.js
@@ -57,6 +57,13 @@ export function createLogger({ emailFull = false, logFile = null } = {}) {
       if (CONTENT_FIELDS.test(key)) return `[${value.length}ch]`;
       if (value.length > MAX_STRING_LEN) return `[truncated ${value.length}ch]`;
       if (EMAIL_RE.test(value)) return maskEmail(value);
+      // Comma-separated email lists (e.g. cc, bcc fields)
+      if (value.includes(',')) {
+        const parts = value.split(',').map(s => s.trim());
+        if (parts.length > 1 && parts.every(p => EMAIL_RE.test(p))) {
+          return parts.map(maskEmail).join(', ');
+        }
+      }
       return value;
     }
 

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,0 +1,123 @@
+/**
+ * @file lib/log.js
+ * @description Structured logging utilities for the Postmark MCP server.
+ *
+ * Exported via createLogger() so the sanitization and masking logic can be
+ * unit-tested independently of the server runtime.
+ */
+
+import { appendFileSync } from 'fs';
+
+// Fields whose values are always redacted regardless of content.
+const REDACT_PATTERN = /password|secret|token|apikey|api_key/i;
+
+// Fields whose string content is replaced with a byte-count marker.
+const CONTENT_FIELDS = /htmlBody|textBody/i;
+
+// Strings longer than this are truncated even outside known content fields.
+const MAX_STRING_LEN = 300;
+
+// Detects email-like strings so masking can be applied uniformly.
+export const EMAIL_RE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
+
+/**
+ * Creates a logger bound to a specific runtime configuration.
+ *
+ * @param {{ emailFull?: boolean, logFile?: string|null }} opts
+ *   emailFull  – when true, email addresses are not masked in log output
+ *   logFile    – if set, log lines are also appended to this file path
+ *
+ * @returns {{ maskEmail, sanitizeArgs, writeLog }}
+ */
+export function createLogger({ emailFull = false, logFile = null } = {}) {
+
+  /**
+   * Masks an email address for log output:
+   *   user@example.com    → u**r@example.com
+   *   ab@example.com      → a*b@example.com   (2-char: always ≥1 star)
+   *   a@example.com       → a@example.com      (1-char: nothing to mask)
+   * Domain is always preserved in full.
+   * When emailFull is true the original string is returned unchanged.
+   */
+  function maskEmail(email) {
+    if (emailFull) return email;
+    const at = email.lastIndexOf('@');
+    if (at <= 0) return email;
+    const mailbox = email.slice(0, at);
+    const domain  = email.slice(at + 1);
+    if (mailbox.length <= 1) return email;
+    const stars  = '*'.repeat(Math.max(1, mailbox.length - 2));
+    return `${mailbox[0]}${stars}${mailbox[mailbox.length - 1]}@${domain}`;
+  }
+
+  function sanitizeValue(key, value) {
+    if (REDACT_PATTERN.test(key)) return '[redacted]';
+
+    if (typeof value === 'string') {
+      if (CONTENT_FIELDS.test(key)) return `[${value.length}ch]`;
+      if (value.length > MAX_STRING_LEN) return `[truncated ${value.length}ch]`;
+      if (EMAIL_RE.test(value)) return maskEmail(value);
+      return value;
+    }
+
+    if (Array.isArray(value)) {
+      if (value.length === 0) return [];
+      // Message / recipient arrays — surface count + addressees, drop content
+      if (value[0] && typeof value[0] === 'object') {
+        const addrs = value
+          .map(m => m.to || m.email || m.EmailAddress)
+          .filter(Boolean)
+          .map(a => maskEmail(a));
+        return addrs.length
+          ? { _count: value.length, _recipients: addrs.slice(0, 20) }
+          : { _count: value.length };
+      }
+      // Primitive arrays (e.g. array of email strings)
+      const items = value.length <= 20
+        ? value
+        : [...value.slice(0, 20), `…+${value.length - 20} more`];
+      return items.map(item =>
+        (typeof item === 'string' && EMAIL_RE.test(item)) ? maskEmail(item) : item
+      );
+    }
+
+    // Arbitrary data objects (templateModel etc.) — show key names, not values
+    if (value && typeof value === 'object') return { _keys: Object.keys(value) };
+
+    return value;
+  }
+
+  /**
+   * Returns a sanitized copy of a tool-arguments object safe for logging.
+   * All sensitive, large, or PII-bearing values are replaced in-place.
+   */
+  function sanitizeArgs(args) {
+    if (!args || typeof args !== 'object') return {};
+    return Object.fromEntries(
+      Object.entries(args).map(([k, v]) => [k, sanitizeValue(k, v)])
+    );
+  }
+
+  /**
+   * Writes a JSON log entry to stderr. If logFile is configured, also appends
+   * to that file. File write failures are reported as a warning line on stderr
+   * and never propagate to the caller.
+   */
+  function writeLog(entry) {
+    const line = JSON.stringify(entry);
+    process.stderr.write(line + '\n');
+    if (logFile) {
+      try {
+        appendFileSync(logFile, line + '\n');
+      } catch (e) {
+        process.stderr.write(JSON.stringify({
+          timestamp: new Date().toISOString(),
+          level: 'warn',
+          message: `LOG_FILE write failed: ${e.message}`,
+        }) + '\n');
+      }
+    }
+  }
+
+  return { maskEmail, sanitizeArgs, writeLog };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1156 @@
+{
+  "name": "@activecampaign/postmark-mcp",
+  "version": "2.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@activecampaign/postmark-mcp",
+      "version": "2.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "dotenv": "^16.4.5",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.1.tgz",
+      "integrity": "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,8 +1,17 @@
 {
   "name": "@activecampaign/postmark-mcp",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Official Postmark MCP server for sending emails via Claude and AI assistants",
-  "keywords": ["postmark", "activecampaign", "email", "mcp", "model-context-protocol", "claude", "cursor", "ai"],
+  "keywords": [
+    "postmark",
+    "activecampaign",
+    "email",
+    "mcp",
+    "model-context-protocol",
+    "claude",
+    "cursor",
+    "ai"
+  ],
   "author": "Jabal Torres",
   "license": "MIT",
   "repository": {
@@ -36,9 +45,9 @@
     "smoke": "node smoke-test.mjs"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.12.1",
-    "dotenv": "^16.4.5",
-    "zod": "^3.23.8"
+    "@modelcontextprotocol/sdk": "1.29.0",
+    "dotenv": "16.6.1",
+    "zod": "3.25.76"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "start": "node index.js",
     "test": "node --test test-unit.mjs",
     "test:offline": "node --test test-offline.mjs",
+    "test:e2e": "node --test test-e2e.mjs",
     "inspector": "npx @modelcontextprotocol/inspector index.js",
     "smoke": "node smoke-test.mjs"
   },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,10 @@
     "test:offline": "node --test test-offline.mjs",
     "test:e2e": "node --test test-e2e.mjs",
     "inspector": "npx @modelcontextprotocol/inspector index.js",
-    "smoke": "node smoke-test.mjs"
+    "presmoke": "node --input-type=module --eval \"import{existsSync}from'fs';if(!existsSync('./smoke-test.mjs')){console.error('\\nsmoke-test.mjs not found.\\nCopy the example file and add your verified sender address:\\n\\n  cp smoke-test.example.mjs smoke-test.mjs\\n\\nThen edit smoke-test.mjs and set FROM_EMAIL to a verified Postmark sender.\\n');process.exit(1)}\"",
+    "smoke": "node smoke-test.mjs",
+    "presmoke:mutating": "node --input-type=module --eval \"import{existsSync}from'fs';if(!existsSync('./smoke-test-mutating.mjs')){console.error('\\nsmoke-test-mutating.mjs not found.\\nCopy the example file and add your verified sender address:\\n\\n  cp smoke-test-mutating.example.mjs smoke-test-mutating.mjs\\n\\nThen edit smoke-test-mutating.mjs and set FROM_EMAIL to a verified Postmark sender.\\n');process.exit(1)}\"",
+    "smoke:mutating": "node smoke-test-mutating.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.29.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "files": [
     "index.js",
+    "lib/",
     "README.md",
     "LICENSE",
     "CHANGELOG.md",
@@ -28,6 +29,8 @@
   ],
   "scripts": {
     "start": "node index.js",
+    "test": "node --test test-unit.mjs",
+    "test:offline": "node --test test-offline.mjs",
     "inspector": "npx @modelcontextprotocol/inspector index.js",
     "smoke": "node smoke-test.mjs"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,11 @@
     "cursor",
     "ai"
   ],
-  "author": "Jabal Torres",
+  "author": {
+    "name": "Postmark",
+    "email": "support@postmarkapp.com",
+    "url": "https://postmarkapp.com"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/test-e2e.mjs
+++ b/test-e2e.mjs
@@ -1,0 +1,182 @@
+/**
+ * Tier 3: end-to-end env-var wiring tests.
+ *
+ * Verifies that LOG_FILE, LOG_EMAIL_FULL, and MCP client identity are all
+ * wired correctly through the running server. No Postmark account required —
+ * tool calls are expected to fail at the network level, but the logging
+ * wrapper fires regardless and writes the LOG_FILE entry.
+ *
+ * Run:  node --test test-e2e.mjs
+ *  or:  npm run test:e2e
+ */
+
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync, unlinkSync, mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+async function startServer(extraEnv = {}) {
+  const transport = new StdioClientTransport({
+    command: 'node',
+    args: ['index.js'],
+    env: {
+      ...process.env,
+      POSTMARK_SERVER_TOKEN: 'POSTMARK_API_TEST',
+      DEFAULT_SENDER_EMAIL: 'sender@example.com',
+      DEFAULT_MESSAGE_STREAM: 'outbound',
+      POSTMARK_SKIP_VERIFY: 'true',
+      ...extraEnv,
+    },
+  });
+  const client = new Client({ name: 'test-e2e', version: '1.2.3' });
+  await client.connect(transport);
+  return client;
+}
+
+/** Reads all newline-delimited JSON entries from a log file. */
+function readLogEntries(path) {
+  return readFileSync(path, 'utf8')
+    .split('\n')
+    .filter(Boolean)
+    .map(line => JSON.parse(line));
+}
+
+// ─── Shared server (LOG_FILE tests + client identity) ─────────────────────────
+
+let sharedLogFile;
+let sharedServer;
+
+before(async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'postmark-mcp-e2e-'));
+  sharedLogFile = join(dir, 'server.log');
+  sharedServer = await startServer({ LOG_FILE: sharedLogFile });
+
+  // Trigger one tool invocation; getServerInfo has no required args.
+  // It will fail at the Postmark API level (fetch / 401) but that is fine —
+  // the logging wrapper always writes the log entry.
+  await sharedServer.callTool({ name: 'getServerInfo', arguments: {} });
+});
+
+after(async () => {
+  await sharedServer?.close();
+  if (sharedLogFile && existsSync(sharedLogFile)) unlinkSync(sharedLogFile);
+});
+
+// ─── LOG_FILE ─────────────────────────────────────────────────────────────────
+
+test('LOG_FILE: log entry is written after a tool invocation', () => {
+  assert.ok(existsSync(sharedLogFile), 'log file should exist after a tool call');
+  const entries = readLogEntries(sharedLogFile);
+  assert.ok(entries.length >= 1, 'log file should contain at least one entry');
+});
+
+test('LOG_FILE: entry contains all required structured fields', () => {
+  const [entry] = readLogEntries(sharedLogFile);
+  assert.ok(entry.timestamp,   'entry should have a timestamp');
+  assert.ok(entry.tool,        'entry should have a tool name');
+  assert.equal(entry.tool, 'getServerInfo');
+  assert.ok('clientName'    in entry, 'entry should have clientName');
+  assert.ok('clientVersion' in entry, 'entry should have clientVersion');
+  assert.ok('args'          in entry, 'entry should have args');
+  assert.ok('status'        in entry, 'entry should have status');
+  assert.ok('durationMs'    in entry, 'entry should have durationMs');
+  assert.ok(typeof entry.durationMs === 'number', 'durationMs should be a number');
+});
+
+test('LOG_FILE: timestamp is a valid ISO 8601 date string', () => {
+  const [entry] = readLogEntries(sharedLogFile);
+  const d = new Date(entry.timestamp);
+  assert.ok(!isNaN(d.getTime()), `timestamp "${entry.timestamp}" is not a valid date`);
+});
+
+// ─── MCP client identity ──────────────────────────────────────────────────────
+
+test('log entry captures clientName and clientVersion from MCP initialize', () => {
+  const [entry] = readLogEntries(sharedLogFile);
+  assert.equal(entry.clientName,    'test-e2e', 'clientName should match the test client name');
+  assert.equal(entry.clientVersion, '1.2.3',    'clientVersion should match the test client version');
+});
+
+// ─── LOG_EMAIL_FULL=false (default) ──────────────────────────────────────────
+
+test('LOG_EMAIL_FULL unset: email address in tool args is masked in log', async () => {
+  const dir  = mkdtempSync(join(tmpdir(), 'postmark-mcp-e2e-'));
+  const file = join(dir, 'masked.log');
+  const client = await startServer({ LOG_FILE: file });
+
+  try {
+    await client.callTool({
+      name: 'sendEmail',
+      arguments: {
+        to:       'alice@example.com',
+        subject:  'Test subject',
+        textBody: 'Test body',
+      },
+    });
+  } finally {
+    await client.close();
+  }
+
+  const entries = readLogEntries(file);
+  assert.ok(entries.length >= 1, 'log file should contain at least one entry');
+  const entry = entries.find(e => e.tool === 'sendEmail');
+  assert.ok(entry, 'should have a sendEmail log entry');
+  assert.notEqual(entry.args.to, 'alice@example.com', 'email should be masked');
+  assert.match(entry.args.to, /^a\*+e@example\.com$/, 'email should follow masking pattern');
+  unlinkSync(file);
+});
+
+// ─── LOG_EMAIL_FULL=true ──────────────────────────────────────────────────────
+
+test('LOG_EMAIL_FULL=true: email address in tool args is NOT masked in log', async () => {
+  const dir  = mkdtempSync(join(tmpdir(), 'postmark-mcp-e2e-'));
+  const file = join(dir, 'full.log');
+  const client = await startServer({ LOG_FILE: file, LOG_EMAIL_FULL: 'true' });
+
+  try {
+    await client.callTool({
+      name: 'sendEmail',
+      arguments: {
+        to:       'alice@example.com',
+        subject:  'Test subject',
+        textBody: 'Test body',
+      },
+    });
+  } finally {
+    await client.close();
+  }
+
+  const entries = readLogEntries(file);
+  const entry = entries.find(e => e.tool === 'sendEmail');
+  assert.ok(entry, 'should have a sendEmail log entry');
+  assert.equal(entry.args.to, 'alice@example.com', 'email should be unmasked when LOG_EMAIL_FULL=true');
+  unlinkSync(file);
+});
+
+// ─── Multiple invocations append ─────────────────────────────────────────────
+
+test('LOG_FILE: multiple tool calls produce separate log entries in order', async () => {
+  const dir  = mkdtempSync(join(tmpdir(), 'postmark-mcp-e2e-'));
+  const file = join(dir, 'multi.log');
+  const client = await startServer({ LOG_FILE: file });
+
+  try {
+    await client.callTool({ name: 'getServerInfo',  arguments: {} });
+    await client.callTool({ name: 'listWebhooks',   arguments: {} });
+    await client.callTool({ name: 'getDeliveryStats', arguments: {} });
+  } finally {
+    await client.close();
+  }
+
+  const entries = readLogEntries(file);
+  assert.equal(entries.length, 3, 'should have one log entry per tool call');
+  assert.equal(entries[0].tool, 'getServerInfo');
+  assert.equal(entries[1].tool, 'listWebhooks');
+  assert.equal(entries[2].tool, 'getDeliveryStats');
+  unlinkSync(file);
+});

--- a/test-offline.mjs
+++ b/test-offline.mjs
@@ -1,0 +1,250 @@
+/**
+ * Tier 2: offline MCP validation tests.
+ *
+ * Tests that run entirely locally — no Postmark account required.
+ * The server is started with POSTMARK_API_TEST as the token; validation
+ * under test fires before any network call is made to Postmark.
+ *
+ * Covers:
+ *   1. createWebhook rejects http:// URLs (Zod schema enforcement)
+ *   2. createWebhook rejects URLs not in WEBHOOK_URL_ALLOWLIST
+ *   3. createWebhook accepts URLs that match the allowlist prefix
+ *   4. All registered tools carry annotation objects
+ *   5. Read-only tools carry readOnlyHint: true
+ *   6. Mutating tools carry readOnlyHint: false, destructiveHint: false
+ *   7. Destructive tools carry destructiveHint: true
+ *
+ * Run:  node --test test-offline.mjs
+ *  or:  npm run test:offline
+ */
+
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+// ─── Server factory ────────────────────────────────────────────────────────────
+
+/**
+ * Spawns index.js over stdio and returns a connected MCP Client.
+ * Caller is responsible for calling client.close() when done.
+ */
+async function startServer(extraEnv = {}) {
+  const transport = new StdioClientTransport({
+    command: 'node',
+    args: ['index.js'],
+    env: {
+      ...process.env,
+      // POSTMARK_API_TEST is the documented Postmark test token — accepted by the
+      // API without a real account, but all validation under test here fires before
+      // any HTTP call reaches Postmark.
+      POSTMARK_SERVER_TOKEN: 'POSTMARK_API_TEST',
+      DEFAULT_SENDER_EMAIL: 'sender@example.com',
+      DEFAULT_MESSAGE_STREAM: 'outbound',
+      POSTMARK_SKIP_VERIFY: 'true',
+      ...extraEnv,
+    },
+  });
+  const client = new Client({ name: 'test-offline', version: '0.0.1' });
+  await client.connect(transport);
+  return client;
+}
+
+/** Calls a tool and returns the MCP result object (never throws on tool errors). */
+async function callTool(client, name, args) {
+  return client.callTool({ name, arguments: args });
+}
+
+/** Returns true when the MCP result represents a tool-level error. */
+function isToolError(result) {
+  return result?.isError === true;
+}
+
+/** Extracts the error text from a tool error result. */
+function errorText(result) {
+  return result?.content?.map(c => c.text ?? '').join(' ') ?? '';
+}
+
+// ─── Webhook URL enforcement ───────────────────────────────────────────────────
+//
+// These tests share a single server instance with no allowlist set.
+
+let serverNoAllowlist;
+
+before(async () => {
+  serverNoAllowlist = await startServer();
+});
+
+after(async () => {
+  await serverNoAllowlist?.close();
+});
+
+test('createWebhook: rejects http:// URL (Zod schema enforcement)', async () => {
+  const result = await callTool(serverNoAllowlist, 'createWebhook', {
+    url: 'http://example.com/hook',
+    openEnabled: true,
+  });
+  assert.ok(isToolError(result), `expected tool error, got: ${JSON.stringify(result)}`);
+});
+
+test('createWebhook: accepts https:// URL when no allowlist is configured', async () => {
+  // With no allowlist the HTTPS check should pass (any HTTPS URL is allowed).
+  // The call WILL reach the Postmark API and fail there, but we only care that
+  // the local validation passes — so we expect an API error, not a Zod error.
+  const result = await callTool(serverNoAllowlist, 'createWebhook', {
+    url: 'https://example.com/hook',
+    openEnabled: true,
+  });
+  // Either the API accepted it (isError false) or Postmark returned an API-level
+  // error — both mean local validation passed. A Zod error would contain "Invalid"
+  // in the message and never reach Postmark at all.
+  if (isToolError(result)) {
+    const text = errorText(result);
+    assert.ok(
+      !text.includes('Invalid') && !text.includes('startsWith'),
+      `local Zod validation should have passed, but got: ${text}`,
+    );
+  }
+});
+
+test('createWebhook: rejects URL missing required trigger flags', async () => {
+  // No trigger enabled — should be rejected by the handler guard before the API.
+  const result = await callTool(serverNoAllowlist, 'createWebhook', {
+    url: 'https://example.com/hook',
+    // intentionally omit all trigger flags
+  });
+  assert.ok(isToolError(result), `expected tool error, got: ${JSON.stringify(result)}`);
+  assert.match(errorText(result), /trigger/i);
+});
+
+// ─── WEBHOOK_URL_ALLOWLIST enforcement ────────────────────────────────────────
+//
+// Each sub-test needs its own server instance with a specific allowlist value.
+
+test('createWebhook: rejects URL not matching WEBHOOK_URL_ALLOWLIST', async () => {
+  const client = await startServer({
+    WEBHOOK_URL_ALLOWLIST: 'https://allowed.example.com,https://also-allowed.example.com',
+  });
+  try {
+    const result = await callTool(client, 'createWebhook', {
+      url: 'https://blocked.example.com/hook',
+      openEnabled: true,
+    });
+    assert.ok(isToolError(result), `expected tool error, got: ${JSON.stringify(result)}`);
+    assert.match(errorText(result), /allowed/i);
+  } finally {
+    await client.close();
+  }
+});
+
+test('createWebhook: accepts URL matching WEBHOOK_URL_ALLOWLIST prefix', async () => {
+  const client = await startServer({
+    WEBHOOK_URL_ALLOWLIST: 'https://allowed.example.com',
+  });
+  try {
+    const result = await callTool(client, 'createWebhook', {
+      url: 'https://allowed.example.com/my/hook',
+      openEnabled: true,
+    });
+    // The URL passed local validation. If Postmark returns an error that's fine —
+    // we only assert the error is NOT our allowlist rejection.
+    if (isToolError(result)) {
+      const text = errorText(result);
+      assert.ok(
+        !text.toLowerCase().includes('allowed'),
+        `should not be rejected by allowlist, but got: ${text}`,
+      );
+    }
+  } finally {
+    await client.close();
+  }
+});
+
+test('createWebhook: accepts first entry of a multi-entry WEBHOOK_URL_ALLOWLIST', async () => {
+  const client = await startServer({
+    WEBHOOK_URL_ALLOWLIST: 'https://first.example.com,https://second.example.com',
+  });
+  try {
+    const result = await callTool(client, 'createWebhook', {
+      url: 'https://first.example.com/hook',
+      openEnabled: true,
+    });
+    if (isToolError(result)) {
+      const text = errorText(result);
+      assert.ok(!text.toLowerCase().includes('allowed'), `unexpected allowlist rejection: ${text}`);
+    }
+  } finally {
+    await client.close();
+  }
+});
+
+// ─── Tool annotations ─────────────────────────────────────────────────────────
+//
+// Verifies that every tool has an annotations object and that the
+// read-only / mutating / destructive hints are applied to the correct tools.
+
+const READ_ONLY_TOOLS = [
+  'listTemplates', 'getTemplate', 'validateTemplate',
+  'searchOutboundMessages', 'getMessageDetails', 'diagnoseDelivery',
+  'searchBounces', 'getBounceDump', 'listSuppressions',
+  'getDeliveryStats', 'getServerInfo', 'listWebhooks',
+];
+
+const MUTATING_TOOLS = [
+  'sendEmail', 'sendEmailWithTemplate', 'sendBatch', 'sendBatchWithTemplate',
+  'createTemplate', 'activateBounce', 'createSuppressions', 'createWebhook',
+];
+
+const DESTRUCTIVE_TOOLS = [
+  'editTemplate', 'deleteTemplate', 'deleteSuppressions', 'deleteWebhook',
+];
+
+test('all tools expose an annotations object', async () => {
+  const { tools } = await serverNoAllowlist.listTools();
+  assert.ok(tools.length > 0, 'server should expose at least one tool');
+  const missing = tools.filter(t => !t.annotations || typeof t.annotations !== 'object');
+  assert.deepEqual(missing.map(t => t.name), [], 'some tools are missing annotations');
+});
+
+test('read-only tools have readOnlyHint: true and destructiveHint: false', async () => {
+  const { tools } = await serverNoAllowlist.listTools();
+  const byName = Object.fromEntries(tools.map(t => [t.name, t]));
+  for (const name of READ_ONLY_TOOLS) {
+    const tool = byName[name];
+    assert.ok(tool, `tool "${name}" not found in listTools response`);
+    assert.equal(tool.annotations?.readOnlyHint, true,  `${name}: readOnlyHint should be true`);
+    assert.equal(tool.annotations?.destructiveHint, false, `${name}: destructiveHint should be false`);
+  }
+});
+
+test('mutating tools have readOnlyHint: false and destructiveHint: false', async () => {
+  const { tools } = await serverNoAllowlist.listTools();
+  const byName = Object.fromEntries(tools.map(t => [t.name, t]));
+  for (const name of MUTATING_TOOLS) {
+    const tool = byName[name];
+    assert.ok(tool, `tool "${name}" not found in listTools response`);
+    assert.equal(tool.annotations?.readOnlyHint,   false, `${name}: readOnlyHint should be false`);
+    assert.equal(tool.annotations?.destructiveHint, false, `${name}: destructiveHint should be false`);
+  }
+});
+
+test('destructive tools have destructiveHint: true and readOnlyHint: false', async () => {
+  const { tools } = await serverNoAllowlist.listTools();
+  const byName = Object.fromEntries(tools.map(t => [t.name, t]));
+  for (const name of DESTRUCTIVE_TOOLS) {
+    const tool = byName[name];
+    assert.ok(tool, `tool "${name}" not found in listTools response`);
+    assert.equal(tool.annotations?.destructiveHint, true,  `${name}: destructiveHint should be true`);
+    assert.equal(tool.annotations?.readOnlyHint,    false, `${name}: readOnlyHint should be false`);
+  }
+});
+
+test('every registered tool belongs to exactly one annotation category', async () => {
+  const { tools } = await serverNoAllowlist.listTools();
+  const categorised = new Set([...READ_ONLY_TOOLS, ...MUTATING_TOOLS, ...DESTRUCTIVE_TOOLS]);
+  const uncategorised = tools.filter(t => !categorised.has(t.name)).map(t => t.name);
+  assert.deepEqual(
+    uncategorised, [],
+    `these tools are not covered by the annotation test lists: ${uncategorised.join(', ')}`,
+  );
+});

--- a/test-offline.mjs
+++ b/test-offline.mjs
@@ -178,6 +178,47 @@ test('createWebhook: accepts first entry of a multi-entry WEBHOOK_URL_ALLOWLIST'
   }
 });
 
+// ─── S1 regression: allowlist bypass vectors ──────────────────────────────────
+//
+// These two URLs pass a naive startsWith() check but resolve to different hosts.
+// Both must be rejected by the fixed URL-parsed allowlist implementation.
+
+test('createWebhook: rejects userinfo bypass (S1 regression)', async () => {
+  // https://allowed.example.com@evil.test/hook
+  // startsWith("https://allowed.example.com") → true, but host === "evil.test"
+  const client = await startServer({
+    WEBHOOK_URL_ALLOWLIST: 'https://allowed.example.com',
+  });
+  try {
+    const result = await callTool(client, 'createWebhook', {
+      url: 'https://allowed.example.com@evil.test/hook',
+      openEnabled: true,
+    });
+    assert.ok(isToolError(result), `expected rejection, got: ${JSON.stringify(result)}`);
+    assert.match(errorText(result), /rejected|allowed/i);
+  } finally {
+    await client.close();
+  }
+});
+
+test('createWebhook: rejects subdomain suffix bypass (S1 regression)', async () => {
+  // https://allowed.example.com.evil.test/hook
+  // startsWith("https://allowed.example.com") → true, but host === "allowed.example.com.evil.test"
+  const client = await startServer({
+    WEBHOOK_URL_ALLOWLIST: 'https://allowed.example.com',
+  });
+  try {
+    const result = await callTool(client, 'createWebhook', {
+      url: 'https://allowed.example.com.evil.test/hook',
+      openEnabled: true,
+    });
+    assert.ok(isToolError(result), `expected rejection, got: ${JSON.stringify(result)}`);
+    assert.match(errorText(result), /rejected|allowed/i);
+  } finally {
+    await client.close();
+  }
+});
+
 // ─── Tool annotations ─────────────────────────────────────────────────────────
 //
 // Verifies that every tool has an annotations object and that the

--- a/test-unit.mjs
+++ b/test-unit.mjs
@@ -1,0 +1,270 @@
+/**
+ * Unit tests for lib/log.js — maskEmail, sanitizeArgs, writeLog.
+ *
+ * No Postmark account or server required. All tests run against pure functions.
+ *
+ * Run:  npm test
+ *  or:  node --test test-unit.mjs
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync, unlinkSync, mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { createLogger } from './lib/log.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const masked   = (opts = {}) => createLogger({ emailFull: false, ...opts });
+const fullMode = (opts = {}) => createLogger({ emailFull: true,  ...opts });
+
+// ─── maskEmail ────────────────────────────────────────────────────────────────
+
+test('maskEmail: normal mailbox masks middle chars, preserves domain', () => {
+  const { maskEmail } = masked();
+  assert.equal(maskEmail('user@example.com'), 'u**r@example.com');
+});
+
+test('maskEmail: 2-char mailbox always injects at least one star', () => {
+  const { maskEmail } = masked();
+  assert.equal(maskEmail('ab@example.com'), 'a*b@example.com');
+});
+
+test('maskEmail: 1-char mailbox is returned unchanged', () => {
+  const { maskEmail } = masked();
+  assert.equal(maskEmail('a@example.com'), 'a@example.com');
+});
+
+test('maskEmail: plus-addressed mailbox masks correctly', () => {
+  const { maskEmail } = masked();
+  assert.equal(maskEmail('contact+tag@postmarkapp.com'), 'c*********g@postmarkapp.com');
+});
+
+test('maskEmail: dots in mailbox are masked', () => {
+  const { maskEmail } = masked();
+  assert.equal(maskEmail('alice.smith@company.co.uk'), 'a*********h@company.co.uk');
+});
+
+test('maskEmail: multi-part domain is preserved in full', () => {
+  const { maskEmail } = masked();
+  const result = maskEmail('me@sub.domain.example.org');
+  assert.match(result, /@sub\.domain\.example\.org$/);
+});
+
+test('maskEmail: minimal valid email (single-char mailbox) is unchanged', () => {
+  const { maskEmail } = masked();
+  assert.equal(maskEmail('x@y.z'), 'x@y.z');
+});
+
+test('maskEmail: string without @ is returned unchanged', () => {
+  const { maskEmail } = masked();
+  assert.equal(maskEmail('notanemail'), 'notanemail');
+});
+
+test('maskEmail: emailFull=true returns address unchanged', () => {
+  const { maskEmail } = fullMode();
+  assert.equal(maskEmail('user@example.com'), 'user@example.com');
+  assert.equal(maskEmail('ab@example.com'),   'ab@example.com');
+});
+
+// ─── sanitizeArgs — content fields ────────────────────────────────────────────
+
+test('sanitizeArgs: htmlBody replaced with byte count', () => {
+  const { sanitizeArgs } = masked();
+  const body = '<h1>Hello</h1>';
+  const result = sanitizeArgs({ htmlBody: body });
+  assert.equal(result.htmlBody, `[${body.length}ch]`);
+});
+
+test('sanitizeArgs: textBody replaced with byte count', () => {
+  const { sanitizeArgs } = masked();
+  const body = 'Hello world';
+  const result = sanitizeArgs({ textBody: body });
+  assert.equal(result.textBody, `[${body.length}ch]`);
+});
+
+test('sanitizeArgs: string over MAX_STRING_LEN is truncated', () => {
+  const { sanitizeArgs } = masked();
+  const long = 'x'.repeat(301);
+  const result = sanitizeArgs({ subject: long });
+  assert.match(result.subject, /^\[truncated 301ch\]$/);
+});
+
+test('sanitizeArgs: string under MAX_STRING_LEN passes through', () => {
+  const { sanitizeArgs } = masked();
+  const result = sanitizeArgs({ subject: 'Meeting Reminder' });
+  assert.equal(result.subject, 'Meeting Reminder');
+});
+
+// ─── sanitizeArgs — redaction ─────────────────────────────────────────────────
+
+test('sanitizeArgs: field named "apikey" is redacted', () => {
+  const { sanitizeArgs } = masked();
+  assert.equal(sanitizeArgs({ apikey: 'sk-abc123' }).apikey, '[redacted]');
+});
+
+test('sanitizeArgs: field named "secret" is redacted', () => {
+  const { sanitizeArgs } = masked();
+  assert.equal(sanitizeArgs({ secret: 'super-secret' }).secret, '[redacted]');
+});
+
+test('sanitizeArgs: field named "password" is redacted', () => {
+  const { sanitizeArgs } = masked();
+  assert.equal(sanitizeArgs({ password: 'hunter2' }).password, '[redacted]');
+});
+
+test('sanitizeArgs: field named "token" is redacted', () => {
+  const { sanitizeArgs } = masked();
+  assert.equal(sanitizeArgs({ token: 'abc' }).token, '[redacted]');
+});
+
+test('sanitizeArgs: field named "secretToken" (mixed case) is redacted', () => {
+  const { sanitizeArgs } = masked();
+  assert.equal(sanitizeArgs({ secretToken: 'xyz' }).secretToken, '[redacted]');
+});
+
+// ─── sanitizeArgs — email masking ─────────────────────────────────────────────
+
+test('sanitizeArgs: email string values are masked', () => {
+  const { sanitizeArgs } = masked();
+  const result = sanitizeArgs({ to: 'user@example.com' });
+  assert.equal(result.to, 'u**r@example.com');
+});
+
+test('sanitizeArgs: emailFull=true leaves email values unmasked', () => {
+  const { sanitizeArgs } = fullMode();
+  const result = sanitizeArgs({ to: 'user@example.com' });
+  assert.equal(result.to, 'user@example.com');
+});
+
+test('sanitizeArgs: non-email strings are not masked', () => {
+  const { sanitizeArgs } = masked();
+  const result = sanitizeArgs({ tag: 'onboarding', messageStream: 'outbound' });
+  assert.equal(result.tag, 'onboarding');
+  assert.equal(result.messageStream, 'outbound');
+});
+
+// ─── sanitizeArgs — scalars and primitives ────────────────────────────────────
+
+test('sanitizeArgs: boolean values pass through', () => {
+  const { sanitizeArgs } = masked();
+  const result = sanitizeArgs({ openEnabled: true, deliveryEnabled: false });
+  assert.equal(result.openEnabled, true);
+  assert.equal(result.deliveryEnabled, false);
+});
+
+test('sanitizeArgs: number values pass through', () => {
+  const { sanitizeArgs } = masked();
+  const result = sanitizeArgs({ count: 50, offset: 0, bounceId: 123456 });
+  assert.equal(result.count, 50);
+  assert.equal(result.bounceId, 123456);
+});
+
+// ─── sanitizeArgs — objects ───────────────────────────────────────────────────
+
+test('sanitizeArgs: templateModel object replaced with key list', () => {
+  const { sanitizeArgs } = masked();
+  const result = sanitizeArgs({ templateModel: { name: 'Alice', plan: 'Pro', token: 'xyz' } });
+  assert.deepEqual(result.templateModel, { _keys: ['name', 'plan', 'token'] });
+});
+
+test('sanitizeArgs: empty object replaced with empty key list', () => {
+  const { sanitizeArgs } = masked();
+  const result = sanitizeArgs({ templateModel: {} });
+  assert.deepEqual(result.templateModel, { _keys: [] });
+});
+
+// ─── sanitizeArgs — arrays ────────────────────────────────────────────────────
+
+test('sanitizeArgs: empty array stays empty', () => {
+  const { sanitizeArgs } = masked();
+  assert.deepEqual(sanitizeArgs({ items: [] }).items, []);
+});
+
+test('sanitizeArgs: messages array summarised as { _count, _recipients } with masked emails', () => {
+  const { sanitizeArgs } = masked();
+  const result = sanitizeArgs({
+    messages: [
+      { to: 'alice@example.com', subject: 'Hi', textBody: 'Hello' },
+      { to: 'bob@example.com',   subject: 'Hey', textBody: 'World' },
+    ],
+  });
+  assert.deepEqual(result.messages, {
+    _count: 2,
+    _recipients: ['a***e@example.com', 'b*b@example.com'],
+  });
+});
+
+test('sanitizeArgs: recipients array (sendBatchWithTemplate) summarised correctly', () => {
+  const { sanitizeArgs } = masked();
+  const result = sanitizeArgs({
+    recipients: [
+      { to: 'user@example.com', templateModel: { name: 'Alice' } },
+      { to: 'ab@corp.io',       templateModel: { name: 'Bob' } },
+    ],
+  });
+  assert.equal(result.recipients._count, 2);
+  assert.deepEqual(result.recipients._recipients, ['u**r@example.com', 'a*b@corp.io']);
+});
+
+test('sanitizeArgs: emailAddresses primitive array has each email masked', () => {
+  const { sanitizeArgs } = masked();
+  const result = sanitizeArgs({
+    emailAddresses: ['user@example.com', 'ab@corp.io', 'a@x.com'],
+  });
+  assert.deepEqual(result.emailAddresses, ['u**r@example.com', 'a*b@corp.io', 'a@x.com']);
+});
+
+test('sanitizeArgs: emailAddresses with emailFull=true are unmasked', () => {
+  const { sanitizeArgs } = fullMode();
+  const result = sanitizeArgs({ emailAddresses: ['user@example.com', 'ab@corp.io'] });
+  assert.deepEqual(result.emailAddresses, ['user@example.com', 'ab@corp.io']);
+});
+
+test('sanitizeArgs: large primitive array is truncated with a tail marker', () => {
+  const { sanitizeArgs } = masked();
+  const bigArray = Array.from({ length: 25 }, (_, i) => `item-${i}`);
+  const result = sanitizeArgs({ items: bigArray });
+  assert.equal(result.items.length, 21); // 20 items + tail marker
+  assert.match(result.items[20], /\+5 more/);
+});
+
+// ─── writeLog / LOG_FILE ──────────────────────────────────────────────────────
+
+test('writeLog: writes JSON line to LOG_FILE', () => {
+  const dir  = mkdtempSync(join(tmpdir(), 'postmark-mcp-test-'));
+  const file = join(dir, 'test.log');
+  const { writeLog } = createLogger({ logFile: file });
+
+  writeLog({ tool: 'getServerInfo', status: 'ok', durationMs: 42 });
+
+  const raw = readFileSync(file, 'utf8').trim();
+  const entry = JSON.parse(raw);
+  assert.equal(entry.tool, 'getServerInfo');
+  assert.equal(entry.status, 'ok');
+  assert.equal(entry.durationMs, 42);
+  unlinkSync(file);
+});
+
+test('writeLog: multiple calls append lines (not overwrite)', () => {
+  const dir  = mkdtempSync(join(tmpdir(), 'postmark-mcp-test-'));
+  const file = join(dir, 'test.log');
+  const { writeLog } = createLogger({ logFile: file });
+
+  writeLog({ tool: 'sendEmail',    status: 'ok' });
+  writeLog({ tool: 'listWebhooks', status: 'ok' });
+
+  const lines = readFileSync(file, 'utf8').trim().split('\n');
+  assert.equal(lines.length, 2);
+  assert.equal(JSON.parse(lines[0]).tool, 'sendEmail');
+  assert.equal(JSON.parse(lines[1]).tool, 'listWebhooks');
+  unlinkSync(file);
+});
+
+test('writeLog: no LOG_FILE does not create a file', () => {
+  const { writeLog } = createLogger({ logFile: null });
+  const path = join(tmpdir(), `postmark-mcp-should-not-exist-${Date.now()}.log`);
+  writeLog({ tool: 'getServerInfo', status: 'ok' });
+  assert.equal(existsSync(path), false);
+});


### PR DESCRIPTION
Security and observability - createWebhook enforces https as well as allows overrides via envvar. MCP tool annotations added. Custom headers added for agent label and client info captured on initialization. Added structured json logging with redactions and masking and LOG_EMAIL_FULL to enable full email in logs if needed. LOG_FILE env var added to allow for logging to txt file. README overhauled to reflect changes and improve accuracy